### PR TITLE
Harden OIDC token validation and fix swarm data race

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 dev.env
 client_secret.txt
+.claude/

--- a/README.md
+++ b/README.md
@@ -43,6 +43,8 @@ service:
       - /var/run/docker.sock:/var/run/docker.sock
 ```
 
+> The examples above mount the Docker socket directly for simplicity. The socket is root-equivalent on the host and grants full control of the swarm — see [Security Considerations](#security-considerations) for a hardened, read-only setup before exposing this app.
+
 ## Configuration
 
 General Environment Variables:
@@ -94,6 +96,67 @@ The Docker API can expose potentially sensitive information. There are several m
 - To manage things on a service by service level, use labels on the desired service (with `io.github.jtgasper3.visualizer.hide-labels`) and environment variables (`io.github.jtgasper3.visualizer.hide-envs`) to specify a comma separated list of label or environment variables to remove from the service's specific labels or environment variable values from the output. The value is changes to "(sanitized)".
 
 For very granular control over uses that we didn't consider, use the environment variable of `SENSITIVE_DATA_PATHS` and a comma separated list of paths to remove. Examine the JSON output and find and specify the path to remove. Use `*` for arrays, and use single quotes to delimit values of property names that have embedded periods (i.e. `services.*.Spec.TaskTemplate.ContainerSpec.Labels.'desktop.docker.io/mounts/0/Source'`).
+
+
+## Security Considerations
+
+Securing a deployment is the operator's responsibility. The two items below have the largest impact and are not handled by the application itself.
+
+### Restrict access to the Docker socket
+
+This app reads cluster state from the Docker Engine API. Mounting `/var/run/docker.sock` directly (as the Usage examples do for brevity) hands the container full, **root-equivalent** control of the host and the entire swarm. The app only ever performs *read* operations (listing nodes, services, tasks, and networks), so it does not need that level of access.
+
+For anything beyond local development, place a read-only socket proxy between the app and the Docker socket and grant it only the endpoints this app uses. The app honors the standard `DOCKER_HOST` variable, so point it at the proxy and drop the socket mount entirely:
+
+```yaml
+services:
+  dockerproxy:
+    image: ghcr.io/tecnativa/docker-socket-proxy:latest
+    environment:
+      # Grant only the read endpoints this app needs; everything else stays denied,
+      # and the proxy rejects all write (POST/PUT/DELETE) calls by default.
+      NODES: 1
+      SERVICES: 1
+      TASKS: 1
+      NETWORKS: 1
+    deploy:
+      placement:
+        constraints:
+          - node.role == manager   # swarm reads must run on a manager
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock:ro
+    networks:
+      - viz
+
+  viz:
+    image: jtgasper3/swarm-visualizer:latest
+    environment:
+      CLUSTER_NAME: Dev Cluster
+      DOCKER_HOST: tcp://dockerproxy:2375
+    ports:
+      - 8080:8080
+    networks:
+      - viz
+    # No docker.sock mount and no manager constraint needed on the app itself —
+    # only the proxy talks to the socket and must run on a manager.
+
+networks:
+  viz:
+    driver: overlay
+```
+
+With this setup the application can no longer issue write commands to the daemon, so a compromise of the app cannot be escalated into control of the cluster.
+
+### Authentication is not authorization
+
+Setting `ENABLE_AUTHN=true` enables *authentication* only: it verifies that a request carries a valid, unexpired ID token issued by your configured identity provider for this client (the token's signature, `aud`, and `iss` are checked). It does **not** perform *authorization* — there is no per-user, group, or role check. **Any identity your IdP will issue such a token to can view the dashboard.**
+
+To control *who* may access the app, restrict it at the boundaries:
+
+- **At the identity provider** — assign an application role, or limit the app registration / enterprise application to specific users or groups, so the IdP only issues tokens to intended users.
+- **At a reverse proxy** — enforce an allow-list or forward-auth policy in front of the app.
+
+Combine access control with the *Data Sanitization* options above to limit what authenticated users can see (environment variables, mount sources, configs, and labels are exposed unless hidden).
 
 
 ## Development/Testing

--- a/deployment/docker-stack.yml
+++ b/deployment/docker-stack.yml
@@ -26,6 +26,9 @@ services:
     secrets:
       - client_secret
     volumes:
+      # Direct socket mount is root-equivalent host access. For production, front
+      # it with a read-only socket proxy instead — see "Security Considerations"
+      # in the README.
       - /var/run/docker.sock:/var/run/docker.sock
     
 secrets:

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1,7 +1,6 @@
 package config
 
 import (
-	"crypto/rsa"
 	"log"
 	"net"
 	"os"
@@ -32,15 +31,15 @@ type OAuthConfig struct {
 	AuthURL          string
 	TokenURL         string
 	OIDCWellKnownURL string
-	RsaPublicKeyMap  map[string]*rsa.PublicKey
+	Issuer           string
 	UsernameClaim    string
 	SessionMaxAge    int
 }
 
 const (
-	defaultContextRoot    = "/"
-	defaultListenerPort   = "8080"
-	defaultSessionMaxAge  = 3600
+	defaultContextRoot   = "/"
+	defaultListenerPort  = "8080"
+	defaultSessionMaxAge = 3600
 )
 
 func LoadConfig() *Config {
@@ -121,7 +120,6 @@ func LoadConfig() *Config {
 			AuthURL:          os.Getenv("OIDC_AUTH_URL"),
 			TokenURL:         os.Getenv("OIDC_TOKEN_URL"),
 			OIDCWellKnownURL: os.Getenv("OIDC_WELL_KNOWN_URL"),
-			RsaPublicKeyMap:  make(map[string]*rsa.PublicKey),
 			UsernameClaim:    getEnv("OIDC_USERNAME_CLAIM", "preferred_username"),
 			SessionMaxAge:    sessionMaxAge,
 		},

--- a/internal/docker/handlers.go
+++ b/internal/docker/handlers.go
@@ -27,8 +27,8 @@ var (
 			return u.Host == r.Host
 		},
 	}
-	clients  = make(map[*websocket.Conn]bool)
-	mu       sync.Mutex
+	clients = make(map[*websocket.Conn]bool)
+	mu      sync.Mutex
 )
 
 func RegisterDockerHandlers(cfg *config.Config) {
@@ -62,7 +62,7 @@ func handleConnections(cfg *config.Config, w http.ResponseWriter, r *http.Reques
 		log.Printf("Client connected: %s", r.RemoteAddr)
 	}
 
-	jsonBytes, err := json.Marshal(lastBroadcastedData)
+	jsonBytes, err := json.Marshal(lastBroadcastedData.Load())
 	if err != nil {
 		log.Println("Error marshalling combined data:", err)
 

--- a/internal/docker/inspect.go
+++ b/internal/docker/inspect.go
@@ -8,6 +8,7 @@ import (
 	"reflect"
 	"slices"
 	"strings"
+	"sync/atomic"
 	"time"
 
 	"github.com/jtgasper3/swarm-visualizer/internal"
@@ -32,8 +33,10 @@ type cachedTask struct {
 }
 
 var (
-	broadcast           = make(chan []byte)
-	lastBroadcastedData *SwarmData
+	broadcast = make(chan []byte)
+	// lastBroadcastedData is read by WebSocket handler goroutines while the
+	// single inspectSwarmServices goroutine swaps it, so access is atomic.
+	lastBroadcastedData atomic.Pointer[SwarmData]
 	// stoppedTaskCache is only accessed from the single inspectSwarmServices goroutine.
 	stoppedTaskCache = make(map[string]cachedTask)
 )
@@ -74,8 +77,8 @@ func inspectSwarmServices(cfg *config.Config) {
 			}
 		}
 
-		if lastBroadcastedData == nil || !reflect.DeepEqual(data, *lastBroadcastedData) {
-			lastBroadcastedData = &data
+		if prev := lastBroadcastedData.Load(); prev == nil || !reflect.DeepEqual(data, *prev) {
+			lastBroadcastedData.Store(&data)
 			jsonBytes, err := json.Marshal(data)
 			if err != nil {
 				log.Println("Error marshalling combined data:", err)

--- a/internal/docker/inspect_test.go
+++ b/internal/docker/inspect_test.go
@@ -3,9 +3,9 @@ package docker
 import (
 	"testing"
 
+	"github.com/jtgasper3/swarm-visualizer/internal/config"
 	"github.com/moby/moby/api/types/mount"
 	"github.com/moby/moby/api/types/swarm"
-	"github.com/jtgasper3/swarm-visualizer/internal/config"
 )
 
 func TestSanitizeNodes_HideLabels(t *testing.T) {

--- a/internal/oauth/idtoken.go
+++ b/internal/oauth/idtoken.go
@@ -33,7 +33,10 @@ func ValidateToken(cfg *config.Config, r *http.Request) (jwt.MapClaims, error) {
 			return nil, fmt.Errorf("missing kid in token header")
 		}
 
-		rsaPublicKey, ok := cfg.OAuthConfig.RsaPublicKeyMap[kid]
+		if signingKeys == nil {
+			return nil, fmt.Errorf("signing keys not initialized")
+		}
+		rsaPublicKey, ok := signingKeys.key(kid)
 		if !ok {
 			return nil, fmt.Errorf("unknown kid: %s", kid)
 		}
@@ -47,6 +50,16 @@ func ValidateToken(cfg *config.Config, r *http.Request) (jwt.MapClaims, error) {
 	claims, ok := token.Claims.(jwt.MapClaims)
 	if !ok || !token.Valid {
 		return nil, fmt.Errorf("unauthorized")
+	}
+
+	if cfg.OAuthConfig.Issuer != "" {
+		issuer, err := claims.GetIssuer()
+		if err != nil {
+			return nil, fmt.Errorf("failed to read issuer claim: %v", err)
+		}
+		if issuer != cfg.OAuthConfig.Issuer {
+			return nil, fmt.Errorf("ID token from unexpected issuer: %s", issuer)
+		}
 	}
 
 	audiences, err := claims.GetAudience()

--- a/internal/oauth/idtoken_test.go
+++ b/internal/oauth/idtoken_test.go
@@ -1,0 +1,141 @@
+package oauth
+
+import (
+	"crypto/rand"
+	"crypto/rsa"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/golang-jwt/jwt/v5"
+	"github.com/jtgasper3/swarm-visualizer/internal/config"
+)
+
+func TestValidateToken(t *testing.T) {
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatalf("generate key: %v", err)
+	}
+	otherKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatalf("generate other key: %v", err)
+	}
+
+	const (
+		kid    = "test-kid"
+		issuer = "https://issuer.example.com"
+		client = "client-123"
+	)
+
+	// Point the package-level key store at our test key.
+	orig := signingKeys
+	t.Cleanup(func() { signingKeys = orig })
+	signingKeys = &keyStore{
+		keys:        map[string]*rsa.PublicKey{kid: &key.PublicKey},
+		lastRefresh: time.Now(),
+	}
+
+	validClaims := func() jwt.MapClaims {
+		return jwt.MapClaims{
+			"iss": issuer,
+			"aud": client,
+			"sub": "user-1",
+			"exp": time.Now().Add(time.Hour).Unix(),
+			"iat": time.Now().Unix(),
+		}
+	}
+
+	signRS256 := func(claims jwt.MapClaims, signKey *rsa.PrivateKey, hdrKid string) string {
+		tok := jwt.NewWithClaims(jwt.SigningMethodRS256, claims)
+		tok.Header["kid"] = hdrKid
+		s, err := tok.SignedString(signKey)
+		if err != nil {
+			t.Fatalf("sign token: %v", err)
+		}
+		return s
+	}
+
+	// alg:none token — must be rejected by the RSA-only key function.
+	noneTok := jwt.NewWithClaims(jwt.SigningMethodNone, validClaims())
+	noneTok.Header["kid"] = kid
+	noneStr, err := noneTok.SignedString(jwt.UnsafeAllowNoneSignatureType)
+	if err != nil {
+		t.Fatalf("sign none token: %v", err)
+	}
+
+	// HMAC token — an algorithm-confusion attempt, also rejected.
+	hmacTok := jwt.NewWithClaims(jwt.SigningMethodHS256, validClaims())
+	hmacTok.Header["kid"] = kid
+	hmacStr, err := hmacTok.SignedString([]byte("symmetric-secret"))
+	if err != nil {
+		t.Fatalf("sign hmac token: %v", err)
+	}
+
+	expiredClaims := validClaims()
+	expiredClaims["exp"] = time.Now().Add(-time.Hour).Unix()
+
+	wrongAudClaims := validClaims()
+	wrongAudClaims["aud"] = "someone-else"
+
+	wrongIssClaims := validClaims()
+	wrongIssClaims["iss"] = "https://evil.example.com"
+
+	defaultCfg := &config.Config{OAuthConfig: config.OAuthConfig{ClientID: client, Issuer: issuer}}
+
+	tests := []struct {
+		name    string
+		token   string
+		bearer  bool
+		noToken bool
+		cfg     *config.Config
+		wantErr bool
+	}{
+		{name: "valid token via cookie", token: signRS256(validClaims(), key, kid)},
+		{name: "valid token via bearer header", token: signRS256(validClaims(), key, kid), bearer: true},
+		{name: "issuer not configured skips check", token: signRS256(wrongIssClaims, key, kid), cfg: &config.Config{OAuthConfig: config.OAuthConfig{ClientID: client}}},
+		{name: "expired token", token: signRS256(expiredClaims, key, kid), wantErr: true},
+		{name: "wrong audience", token: signRS256(wrongAudClaims, key, kid), wantErr: true},
+		{name: "wrong issuer", token: signRS256(wrongIssClaims, key, kid), wantErr: true},
+		{name: "unknown kid", token: signRS256(validClaims(), key, "other-kid"), wantErr: true},
+		{name: "wrong signing key", token: signRS256(validClaims(), otherKey, kid), wantErr: true},
+		{name: "alg none rejected", token: noneStr, wantErr: true},
+		{name: "hmac signature rejected", token: hmacStr, wantErr: true},
+		{name: "no token", noToken: true, wantErr: true},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := tc.cfg
+			if cfg == nil {
+				cfg = defaultCfg
+			}
+
+			req := httptest.NewRequest(http.MethodGet, "/ws", nil)
+			if !tc.noToken {
+				if tc.bearer {
+					req.Header.Set("Authorization", "Bearer "+tc.token)
+				} else {
+					req.AddCookie(&http.Cookie{Name: "id_token", Value: tc.token})
+				}
+			}
+
+			claims, err := ValidateToken(cfg, req)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("expected error, got nil (claims=%v)", claims)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if claims == nil {
+				t.Fatal("expected claims, got nil")
+			}
+			if sub, _ := claims.GetSubject(); sub != "user-1" {
+				t.Errorf("sub = %q, want user-1", sub)
+			}
+		})
+	}
+}

--- a/internal/oauth/jwks.go
+++ b/internal/oauth/jwks.go
@@ -1,0 +1,152 @@
+package oauth
+
+import (
+	"crypto/rsa"
+	"crypto/x509"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"log"
+	"net/http"
+	"sync"
+	"time"
+)
+
+const (
+	// jwksRefreshInterval is how often signing keys are proactively re-fetched
+	// so the server keeps working across IdP key rotations.
+	jwksRefreshInterval = time.Hour
+	// jwksRefreshThrottle is the minimum spacing between on-demand refreshes
+	// triggered by an unknown key id, so a flood of bogus kids can't hammer
+	// the identity provider.
+	jwksRefreshThrottle = time.Minute
+)
+
+// keyStore holds the identity provider's RSA signing keys and keeps them
+// current. It is safe for concurrent use.
+type keyStore struct {
+	jwksURI    string
+	httpClient *http.Client
+
+	mu          sync.RWMutex
+	keys        map[string]*rsa.PublicKey
+	lastRefresh time.Time
+}
+
+// signingKeys is populated during OIDC discovery (fetchWellKnownOIDCConfig)
+// before any token is validated.
+var signingKeys *keyStore
+
+// newKeyStore creates a key store for the given JWKS endpoint. Callers must
+// invoke refresh once to populate it before validating tokens.
+func newKeyStore(jwksURI string, httpClient *http.Client) *keyStore {
+	return &keyStore{
+		jwksURI:    jwksURI,
+		httpClient: httpClient,
+		keys:       make(map[string]*rsa.PublicKey),
+	}
+}
+
+// key returns the RSA public key for the given key id. If the kid is unknown
+// (e.g. the IdP rotated its keys) it triggers a throttled refresh and retries
+// once.
+func (ks *keyStore) key(kid string) (*rsa.PublicKey, bool) {
+	ks.mu.RLock()
+	k, ok := ks.keys[kid]
+	ks.mu.RUnlock()
+	if ok {
+		return k, true
+	}
+
+	if !ks.refreshIfStale() {
+		return nil, false
+	}
+
+	ks.mu.RLock()
+	k, ok = ks.keys[kid]
+	ks.mu.RUnlock()
+	return k, ok
+}
+
+// refreshIfStale refreshes the JWKS only if the last attempt was more than
+// jwksRefreshThrottle ago. It reports whether a refresh was attempted.
+func (ks *keyStore) refreshIfStale() bool {
+	ks.mu.RLock()
+	fresh := time.Since(ks.lastRefresh) < jwksRefreshThrottle
+	ks.mu.RUnlock()
+	if fresh {
+		return false
+	}
+	if err := ks.refresh(); err != nil {
+		log.Printf("JWKS on-demand refresh failed: %v", err)
+	}
+	return true
+}
+
+// refresh fetches the JWKS and atomically replaces the in-memory key set.
+func (ks *keyStore) refresh() error {
+	// Record the attempt up front so failures are throttled too.
+	ks.mu.Lock()
+	ks.lastRefresh = time.Now()
+	ks.mu.Unlock()
+
+	resp, err := ks.httpClient.Get(ks.jwksURI)
+	if err != nil {
+		return fmt.Errorf("failed to fetch JWKS: %v", err)
+	}
+	defer resp.Body.Close()
+
+	var jwks struct {
+		Keys []struct {
+			Kid string   `json:"kid"`
+			X5c []string `json:"x5c"`
+		} `json:"keys"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&jwks); err != nil {
+		return fmt.Errorf("failed to decode JWKS: %v", err)
+	}
+
+	newKeys := make(map[string]*rsa.PublicKey, len(jwks.Keys))
+	for _, key := range jwks.Keys {
+		if len(key.X5c) == 0 {
+			log.Printf("Skipping JWKS key %s: no x5c certificate data", key.Kid)
+			continue
+		}
+		certData, err := base64.StdEncoding.DecodeString(key.X5c[0])
+		if err != nil {
+			log.Printf("Skipping JWKS key %s: failed to decode certificate: %v", key.Kid, err)
+			continue
+		}
+		cert, err := x509.ParseCertificate(certData)
+		if err != nil {
+			log.Printf("Skipping JWKS key %s: failed to parse certificate: %v", key.Kid, err)
+			continue
+		}
+		rsaPub, ok := cert.PublicKey.(*rsa.PublicKey)
+		if !ok {
+			log.Printf("Skipping JWKS key %s: not an RSA public key", key.Kid)
+			continue
+		}
+		newKeys[key.Kid] = rsaPub
+	}
+
+	if len(newKeys) == 0 {
+		return fmt.Errorf("JWKS contained no usable RSA keys")
+	}
+
+	ks.mu.Lock()
+	ks.keys = newKeys
+	ks.mu.Unlock()
+	return nil
+}
+
+// refreshLoop periodically refreshes the JWKS for the life of the process.
+func (ks *keyStore) refreshLoop() {
+	ticker := time.NewTicker(jwksRefreshInterval)
+	defer ticker.Stop()
+	for range ticker.C {
+		if err := ks.refresh(); err != nil {
+			log.Printf("JWKS periodic refresh failed: %v", err)
+		}
+	}
+}

--- a/internal/oauth/jwks_test.go
+++ b/internal/oauth/jwks_test.go
@@ -1,0 +1,240 @@
+package oauth
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/base64"
+	"encoding/json"
+	"io"
+	"math/big"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+	"time"
+)
+
+// selfSignedDER returns a self-signed certificate (DER bytes) for the given
+// public key, signed by the matching private key.
+func selfSignedDER(t *testing.T, pub, priv any) []byte {
+	t.Helper()
+	tmpl := &x509.Certificate{
+		SerialNumber: big.NewInt(1),
+		Subject:      pkix.Name{CommonName: "test"},
+		NotBefore:    time.Now().Add(-time.Hour),
+		NotAfter:     time.Now().Add(time.Hour),
+	}
+	der, err := x509.CreateCertificate(rand.Reader, tmpl, tmpl, pub, priv)
+	if err != nil {
+		t.Fatalf("create cert: %v", err)
+	}
+	return der
+}
+
+// rsaX5c returns an RSA public key and its base64 x5c certificate entry.
+func rsaX5c(t *testing.T) (*rsa.PublicKey, string) {
+	t.Helper()
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatalf("rsa key: %v", err)
+	}
+	der := selfSignedDER(t, &key.PublicKey, key)
+	return &key.PublicKey, base64.StdEncoding.EncodeToString(der)
+}
+
+// ecX5c returns the base64 x5c certificate entry for a non-RSA (EC) key.
+func ecX5c(t *testing.T) string {
+	t.Helper()
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatalf("ec key: %v", err)
+	}
+	der := selfSignedDER(t, &key.PublicKey, key)
+	return base64.StdEncoding.EncodeToString(der)
+}
+
+type testJWK struct {
+	kid string
+	x5c []string
+}
+
+func jwksBody(t *testing.T, keys ...testJWK) string {
+	t.Helper()
+	type jwk struct {
+		Kid string   `json:"kid"`
+		X5c []string `json:"x5c"`
+	}
+	doc := struct {
+		Keys []jwk `json:"keys"`
+	}{}
+	for _, k := range keys {
+		doc.Keys = append(doc.Keys, jwk{Kid: k.kid, X5c: k.x5c})
+	}
+	b, err := json.Marshal(doc)
+	if err != nil {
+		t.Fatalf("marshal jwks: %v", err)
+	}
+	return string(b)
+}
+
+// jwksHandler serves a configurable JWKS body and counts the number of fetches.
+type jwksHandler struct {
+	mu   sync.Mutex
+	body string
+	hits int
+}
+
+func (h *jwksHandler) setBody(b string) {
+	h.mu.Lock()
+	h.body = b
+	h.mu.Unlock()
+}
+
+func (h *jwksHandler) count() int {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	return h.hits
+}
+
+func (h *jwksHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	h.mu.Lock()
+	h.hits++
+	b := h.body
+	h.mu.Unlock()
+	_, _ = io.WriteString(w, b)
+}
+
+func TestKeyStore_RefreshParsesRSAKeys(t *testing.T) {
+	pub, x5c := rsaX5c(t)
+	h := &jwksHandler{body: jwksBody(t, testJWK{kid: "rsa1", x5c: []string{x5c}})}
+	srv := httptest.NewServer(h)
+	defer srv.Close()
+
+	ks := newKeyStore(srv.URL, srv.Client())
+	if err := ks.refresh(); err != nil {
+		t.Fatalf("refresh: %v", err)
+	}
+
+	got, ok := ks.key("rsa1")
+	if !ok {
+		t.Fatal("expected key rsa1 to be present")
+	}
+	if !got.Equal(pub) {
+		t.Fatal("returned key does not match the certificate key")
+	}
+}
+
+func TestKeyStore_SkipsUnusableKeys(t *testing.T) {
+	pub, rsaCert := rsaX5c(t)
+	ecCert := ecX5c(t)
+	h := &jwksHandler{body: jwksBody(t,
+		testJWK{kid: "rsa1", x5c: []string{rsaCert}},
+		testJWK{kid: "nocert"},                     // no x5c -> skipped
+		testJWK{kid: "ec1", x5c: []string{ecCert}}, // non-RSA -> skipped, not fatal
+	)}
+	srv := httptest.NewServer(h)
+	defer srv.Close()
+
+	ks := newKeyStore(srv.URL, srv.Client())
+	if err := ks.refresh(); err != nil {
+		t.Fatalf("refresh: %v", err)
+	}
+
+	if got, ok := ks.key("rsa1"); !ok || !got.Equal(pub) {
+		t.Fatal("expected usable rsa1 key to be present")
+	}
+	if _, ok := ks.key("nocert"); ok {
+		t.Fatal("key without x5c should be skipped")
+	}
+	if _, ok := ks.key("ec1"); ok {
+		t.Fatal("non-RSA key should be skipped")
+	}
+	// The lookups above should not have triggered another fetch (throttled).
+	if h.count() != 1 {
+		t.Fatalf("expected 1 fetch, got %d", h.count())
+	}
+}
+
+func TestKeyStore_NoUsableKeysReturnsError(t *testing.T) {
+	h := &jwksHandler{body: jwksBody(t, testJWK{kid: "ec1", x5c: []string{ecX5c(t)}})}
+	srv := httptest.NewServer(h)
+	defer srv.Close()
+
+	ks := newKeyStore(srv.URL, srv.Client())
+	if err := ks.refresh(); err == nil {
+		t.Fatal("expected an error when no usable RSA keys are present")
+	}
+}
+
+func TestKeyStore_RetainsKeysOnFailedRefresh(t *testing.T) {
+	pub, rsaCert := rsaX5c(t)
+	h := &jwksHandler{body: jwksBody(t, testJWK{kid: "rsa1", x5c: []string{rsaCert}})}
+	srv := httptest.NewServer(h)
+	defer srv.Close()
+
+	ks := newKeyStore(srv.URL, srv.Client())
+	if err := ks.refresh(); err != nil {
+		t.Fatalf("initial refresh: %v", err)
+	}
+
+	h.setBody("not valid json")
+	if err := ks.refresh(); err == nil {
+		t.Fatal("expected decode error on bad refresh")
+	}
+
+	if got, ok := ks.key("rsa1"); !ok || !got.Equal(pub) {
+		t.Fatal("expected previously loaded key to be retained after a failed refresh")
+	}
+}
+
+func TestKeyStore_RefreshesOnUnknownKid(t *testing.T) {
+	_, cert1 := rsaX5c(t)
+	pub2, cert2 := rsaX5c(t)
+	h := &jwksHandler{body: jwksBody(t, testJWK{kid: "rsa1", x5c: []string{cert1}})}
+	srv := httptest.NewServer(h)
+	defer srv.Close()
+
+	ks := newKeyStore(srv.URL, srv.Client())
+	if err := ks.refresh(); err != nil {
+		t.Fatalf("initial refresh: %v", err)
+	}
+
+	// Rotate the published keys, then age the store past the throttle window so
+	// an unknown kid triggers an on-demand refresh.
+	h.setBody(jwksBody(t, testJWK{kid: "rsa2", x5c: []string{cert2}}))
+	ks.mu.Lock()
+	ks.lastRefresh = time.Now().Add(-2 * jwksRefreshThrottle)
+	ks.mu.Unlock()
+
+	got, ok := ks.key("rsa2")
+	if !ok || !got.Equal(pub2) {
+		t.Fatal("expected rotated key rsa2 to be picked up via on-demand refresh")
+	}
+	if h.count() != 2 {
+		t.Fatalf("expected 2 fetches (initial + on-demand), got %d", h.count())
+	}
+}
+
+func TestKeyStore_ThrottlesUnknownKid(t *testing.T) {
+	_, cert1 := rsaX5c(t)
+	h := &jwksHandler{body: jwksBody(t, testJWK{kid: "rsa1", x5c: []string{cert1}})}
+	srv := httptest.NewServer(h)
+	defer srv.Close()
+
+	ks := newKeyStore(srv.URL, srv.Client())
+	if err := ks.refresh(); err != nil {
+		t.Fatalf("initial refresh: %v", err)
+	}
+
+	// lastRefresh is recent, so an unknown kid must not trigger another fetch.
+	if _, ok := ks.key("missing"); ok {
+		t.Fatal("unknown kid should not resolve")
+	}
+	if h.count() != 1 {
+		t.Fatalf("expected on-demand refresh to be throttled, got %d fetches", h.count())
+	}
+}

--- a/internal/oauth/oauth.go
+++ b/internal/oauth/oauth.go
@@ -3,8 +3,6 @@ package oauth
 import (
 	"context"
 	"crypto/rand"
-	"crypto/rsa"
-	"crypto/x509"
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
@@ -194,61 +192,41 @@ func fetchWellKnownOIDCConfig(cfg *config.Config) error {
 	}
 	defer resp.Body.Close()
 
-	var config struct {
+	var discovery struct {
+		Issuer   string `json:"issuer"`
 		TokenUrl string `json:"token_endpoint"`
 		AuthUrl  string `json:"authorization_endpoint"`
 		JWKSURI  string `json:"jwks_uri"`
 	}
-	if err := json.NewDecoder(resp.Body).Decode(&config); err != nil {
+	if err := json.NewDecoder(resp.Body).Decode(&discovery); err != nil {
 		return fmt.Errorf("failed to decode well-known configuration: %v", err)
 	}
 
+	if discovery.Issuer != "" {
+		cfg.OAuthConfig.Issuer = discovery.Issuer
+	} else {
+		log.Printf("Warning: well-known configuration provided no issuer; ID token issuer validation is disabled")
+	}
+
 	if cfg.OAuthConfig.AuthURL == "" {
-		log.Printf("Using Authorization Endpoint from well-known config %s", config.AuthUrl)
-		cfg.OAuthConfig.AuthURL = config.AuthUrl
+		log.Printf("Using Authorization Endpoint from well-known config %s", discovery.AuthUrl)
+		cfg.OAuthConfig.AuthURL = discovery.AuthUrl
 	}
 	if cfg.OAuthConfig.TokenURL == "" {
-		log.Printf("Using Token Endpoint from well-known config %s", config.TokenUrl)
-		cfg.OAuthConfig.TokenURL = config.TokenUrl
+		log.Printf("Using Token Endpoint from well-known config %s", discovery.TokenUrl)
+		cfg.OAuthConfig.TokenURL = discovery.TokenUrl
 	}
 
-	jwksResp, err := httpClient.Get(config.JWKSURI)
-	if err != nil {
-		return fmt.Errorf("failed to fetch JWKS: %v", err)
-	}
-	defer jwksResp.Body.Close()
-
-	var jwks struct {
-		Keys []struct {
-			Kty string   `json:"kty"`
-			Kid string   `json:"kid"`
-			Use string   `json:"use"`
-			N   string   `json:"n"`
-			E   string   `json:"e"`
-			X5c []string `json:"x5c"`
-		} `json:"keys"`
-	}
-	if err := json.NewDecoder(jwksResp.Body).Decode(&jwks); err != nil {
-		return fmt.Errorf("failed to decode JWKS: %v", err)
+	if discovery.JWKSURI == "" {
+		return fmt.Errorf("well-known configuration provided no jwks_uri")
 	}
 
-	for _, key := range jwks.Keys {
-		if len(key.X5c) == 0 {
-			log.Printf("Skipping JWKS key %s: no x5c certificate data", key.Kid)
-			continue
-		}
-		certData, err := base64.StdEncoding.DecodeString(key.X5c[0])
-		if err != nil {
-			return fmt.Errorf("failed to decode certificate: %v", err)
-		}
-
-		cert, err := x509.ParseCertificate(certData)
-		if err != nil {
-			return fmt.Errorf("failed to parse certificate: %v", err)
-		}
-
-		cfg.OAuthConfig.RsaPublicKeyMap[key.Kid] = cert.PublicKey.(*rsa.PublicKey)
+	signingKeys = newKeyStore(discovery.JWKSURI, httpClient)
+	if err := signingKeys.refresh(); err != nil {
+		return err
 	}
+	go signingKeys.refreshLoop()
+
 	return nil
 }
 

--- a/internal/oauth/oauth.go
+++ b/internal/oauth/oauth.go
@@ -88,13 +88,14 @@ func cleanupAuthLimiters() {
 
 func RegisterOAuthHandlers(cfg *config.Config) {
 	if cfg.AuthEnabled {
-		oauthConfig = setupOAuthConfig(&cfg.OAuthConfig)
-
-		// Fetch and parse the well-known oidc config
+		// Fetch and parse the well-known OIDC config before building the
+		// oauth2.Config so discovered auth/token endpoints are included.
 		err := fetchWellKnownOIDCConfig(cfg)
 		if err != nil {
 			log.Fatalf("Failed to fetch JWKS: %v", err)
 		}
+
+		oauthConfig = setupOAuthConfig(&cfg.OAuthConfig)
 
 		go cleanupAuthLimiters()
 

--- a/internal/oauth/oauth_test.go
+++ b/internal/oauth/oauth_test.go
@@ -4,7 +4,10 @@ import (
 	"net"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
+
+	"github.com/jtgasper3/swarm-visualizer/internal/config"
 )
 
 func mustParseCIDR(s string) *net.IPNet {
@@ -105,5 +108,63 @@ func TestClientIP(t *testing.T) {
 				t.Errorf("clientIP() = %q, want %q", got, tc.want)
 			}
 		})
+	}
+}
+
+func TestRegisterOAuthHandlersUsesDiscoveredEndpoints(t *testing.T) {
+	_, cert := rsaX5c(t)
+	jwks := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(jwksBody(t, testJWK{kid: "rsa1", x5c: []string{cert}})))
+	}))
+	defer jwks.Close()
+
+	discovery := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{
+			"issuer":"https://issuer.example.com",
+			"authorization_endpoint":"https://issuer.example.com/auth",
+			"token_endpoint":"https://issuer.example.com/token",
+			"jwks_uri":"` + jwks.URL + `"
+		}`))
+	}))
+	defer discovery.Close()
+
+	origOAuthConfig := oauthConfig
+	origSigningKeys := signingKeys
+	origMux := http.DefaultServeMux
+	t.Cleanup(func() {
+		oauthConfig = origOAuthConfig
+		signingKeys = origSigningKeys
+		http.DefaultServeMux = origMux
+	})
+	http.DefaultServeMux = http.NewServeMux()
+
+	cfg := &config.Config{
+		ContextRoot: "/",
+		AuthEnabled: true,
+		OAuthConfig: config.OAuthConfig{
+			ClientID:         "client-id",
+			RedirectURL:      "https://app.example.com/callback",
+			OIDCWellKnownURL: discovery.URL,
+		},
+	}
+
+	RegisterOAuthHandlers(cfg)
+
+	if oauthConfig.Endpoint.AuthURL != "https://issuer.example.com/auth" {
+		t.Fatalf("AuthURL = %q, want discovered endpoint", oauthConfig.Endpoint.AuthURL)
+	}
+	if oauthConfig.Endpoint.TokenURL != "https://issuer.example.com/token" {
+		t.Fatalf("TokenURL = %q, want discovered endpoint", oauthConfig.Endpoint.TokenURL)
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/login", nil)
+	req.RemoteAddr = "192.0.2.1:1234"
+	rr := httptest.NewRecorder()
+	http.DefaultServeMux.ServeHTTP(rr, req)
+	loc := rr.Header().Get("Location")
+	if !strings.HasPrefix(loc, "https://issuer.example.com/auth?") {
+		t.Fatalf("login redirect Location = %q, want discovered authorization endpoint", loc)
 	}
 }

--- a/internal/utils_test.go
+++ b/internal/utils_test.go
@@ -1,0 +1,171 @@
+package internal
+
+import "testing"
+
+type clrInner struct {
+	Secret string `json:"secret"`
+	Keep   string `json:"keep"`
+}
+
+type clrOuter struct {
+	Name   string              `json:"name"`
+	Inner  clrInner            `json:"inner"`
+	Items  []clrInner          `json:"items"`
+	M      map[string]clrInner `json:"m"`
+	Labels map[string]string   `json:"labels"`
+	Dotted map[string]string   `json:"dotted"`
+}
+
+func newClrOuter() *clrOuter {
+	return &clrOuter{
+		Name:   "name",
+		Inner:  clrInner{Secret: "s", Keep: "keep"},
+		Items:  []clrInner{{Secret: "s0", Keep: "k0"}, {Secret: "s1", Keep: "k1"}},
+		M:      map[string]clrInner{"x": {Secret: "sx", Keep: "kx"}},
+		Labels: map[string]string{"secret": "v", "keep": "v"},
+		Dotted: map[string]string{"a.b.c": "v"},
+	}
+}
+
+func TestClearByPath(t *testing.T) {
+	tests := []struct {
+		name    string
+		path    string
+		wantErr bool
+		check   func(t *testing.T, o *clrOuter)
+	}{
+		{
+			name: "top-level field by json tag",
+			path: "name",
+			check: func(t *testing.T, o *clrOuter) {
+				if o.Name != "" {
+					t.Errorf("Name = %q, want empty", o.Name)
+				}
+				if o.Inner.Secret != "s" {
+					t.Errorf("Inner.Secret = %q, want unchanged", o.Inner.Secret)
+				}
+			},
+		},
+		{
+			name: "nested struct field",
+			path: "inner.secret",
+			check: func(t *testing.T, o *clrOuter) {
+				if o.Inner.Secret != "" {
+					t.Errorf("Inner.Secret = %q, want empty", o.Inner.Secret)
+				}
+				if o.Inner.Keep != "keep" {
+					t.Errorf("Inner.Keep = %q, want unchanged", o.Inner.Keep)
+				}
+			},
+		},
+		{
+			name: "slice wildcard field",
+			path: "items.*.secret",
+			check: func(t *testing.T, o *clrOuter) {
+				for i, it := range o.Items {
+					if it.Secret != "" {
+						t.Errorf("Items[%d].Secret = %q, want empty", i, it.Secret)
+					}
+					if it.Keep == "" {
+						t.Errorf("Items[%d].Keep cleared unexpectedly", i)
+					}
+				}
+			},
+		},
+		{
+			name: "slice index field",
+			path: "items.0.secret",
+			check: func(t *testing.T, o *clrOuter) {
+				if o.Items[0].Secret != "" {
+					t.Errorf("Items[0].Secret = %q, want empty", o.Items[0].Secret)
+				}
+				if o.Items[1].Secret != "s1" {
+					t.Errorf("Items[1].Secret = %q, want unchanged", o.Items[1].Secret)
+				}
+			},
+		},
+		{
+			name: "struct wildcard clears all fields",
+			path: "inner.*",
+			check: func(t *testing.T, o *clrOuter) {
+				if o.Inner.Secret != "" || o.Inner.Keep != "" {
+					t.Errorf("Inner = %+v, want all fields empty", o.Inner)
+				}
+			},
+		},
+		{
+			name: "map entry by key",
+			path: "labels.secret",
+			check: func(t *testing.T, o *clrOuter) {
+				if o.Labels["secret"] != "" {
+					t.Errorf("Labels[secret] = %q, want empty", o.Labels["secret"])
+				}
+				if o.Labels["keep"] != "v" {
+					t.Errorf("Labels[keep] = %q, want unchanged", o.Labels["keep"])
+				}
+			},
+		},
+		{
+			name: "map wildcard clears all values",
+			path: "m.*",
+			check: func(t *testing.T, o *clrOuter) {
+				v := o.M["x"]
+				if v.Secret != "" || v.Keep != "" {
+					t.Errorf("M[x] = %+v, want zero value", v)
+				}
+			},
+		},
+		{
+			name: "quoted key with embedded dots",
+			path: "dotted.'a.b.c'",
+			check: func(t *testing.T, o *clrOuter) {
+				if o.Dotted["a.b.c"] != "" {
+					t.Errorf("Dotted[a.b.c] = %q, want empty", o.Dotted["a.b.c"])
+				}
+			},
+		},
+		{
+			name: "missing map key is a no-op",
+			path: "labels.absent",
+			check: func(t *testing.T, o *clrOuter) {
+				if o.Labels["secret"] != "v" || o.Labels["keep"] != "v" {
+					t.Errorf("Labels mutated unexpectedly: %v", o.Labels)
+				}
+			},
+		},
+		{
+			name:    "unknown field errors",
+			path:    "nope",
+			wantErr: true,
+		},
+		{
+			name:    "slice index out of range errors",
+			path:    "items.5.secret",
+			wantErr: true,
+		},
+		{
+			name:    "navigate into scalar errors",
+			path:    "name.foo",
+			wantErr: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			o := newClrOuter()
+			err := ClearByPath(o, tc.path)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("expected error for path %q, got nil", tc.path)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error for path %q: %v", tc.path, err)
+			}
+			if tc.check != nil {
+				tc.check(t, o)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- **OIDC hardening**: Replaces the static `RsaPublicKeyMap` in config with a dedicated `keyStore` that fetches JWKS on startup, refreshes hourly, and triggers a throttled on-demand refresh on unknown `kid` values — keeping the server functional across IdP key rotations without hammering the IdP.
- **Issuer validation**: Pulls `issuer` from the OIDC discovery document and validates the `iss` claim on every ID token, closing a gap where tokens from a different IdP could pass audience checks.
- **Data race fix**: Converts `lastBroadcastedData` from a plain pointer to `atomic.Pointer[SwarmData]` so WebSocket handler goroutines and the inspector goroutine no longer race on it.
- **Security Considerations docs**: Adds a README section explaining the Docker socket trust boundary (recommends a read-only socket proxy) and clarifies that `ENABLE_AUTHN=true` enables authentication only, not authorization.
- **Tests**: Adds unit tests for `ValidateToken` (including alg:none and HMAC confusion attacks), `keyStore` refresh/throttle/rotation behavior, and `ClearByPath`.

## Test plan

- [ ] `go test ./...` passes
- [ ] Deploy with OIDC enabled and verify login/token validation still works end-to-end
- [ ] Verify key rotation: rotate IdP signing key, wait for on-demand refresh, confirm tokens signed with the new key are accepted
- [ ] Confirm tokens with a mismatched `iss` are rejected

🤖 Generated with [Claude Code](https://claude.com/claude-code)