### PR TITLE
Fix OIDC discovered endpoint setup

### DIFF
--- a/internal/oauth/oauth.go
+++ b/internal/oauth/oauth.go
@@ -88,13 +88,14 @@ func cleanupAuthLimiters() {
 
 func RegisterOAuthHandlers(cfg *config.Config) {
 	if cfg.AuthEnabled {
-		oauthConfig = setupOAuthConfig(&cfg.OAuthConfig)
-
-		// Fetch and parse the well-known oidc config
+		// Fetch and parse the well-known OIDC config before building the
+		// oauth2.Config so discovered auth/token endpoints are included.
 		err := fetchWellKnownOIDCConfig(cfg)
 		if err != nil {
 			log.Fatalf("Failed to fetch JWKS: %v", err)
 		}
+
+		oauthConfig = setupOAuthConfig(&cfg.OAuthConfig)
 
 		go cleanupAuthLimiters()
 

--- a/internal/oauth/oauth_test.go
+++ b/internal/oauth/oauth_test.go
@@ -4,7 +4,10 @@ import (
 	"net"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
+
+	"github.com/jtgasper3/swarm-visualizer/internal/config"
 )
 
 func mustParseCIDR(s string) *net.IPNet {
@@ -105,5 +108,63 @@ func TestClientIP(t *testing.T) {
 				t.Errorf("clientIP() = %q, want %q", got, tc.want)
 			}
 		})
+	}
+}
+
+func TestRegisterOAuthHandlersUsesDiscoveredEndpoints(t *testing.T) {
+	_, cert := rsaX5c(t)
+	jwks := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(jwksBody(t, testJWK{kid: "rsa1", x5c: []string{cert}})))
+	}))
+	defer jwks.Close()
+
+	discovery := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{
+			"issuer":"https://issuer.example.com",
+			"authorization_endpoint":"https://issuer.example.com/auth",
+			"token_endpoint":"https://issuer.example.com/token",
+			"jwks_uri":"` + jwks.URL + `"
+		}`))
+	}))
+	defer discovery.Close()
+
+	origOAuthConfig := oauthConfig
+	origSigningKeys := signingKeys
+	origMux := http.DefaultServeMux
+	t.Cleanup(func() {
+		oauthConfig = origOAuthConfig
+		signingKeys = origSigningKeys
+		http.DefaultServeMux = origMux
+	})
+	http.DefaultServeMux = http.NewServeMux()
+
+	cfg := &config.Config{
+		ContextRoot: "/",
+		AuthEnabled: true,
+		OAuthConfig: config.OAuthConfig{
+			ClientID:         "client-id",
+			RedirectURL:      "https://app.example.com/callback",
+			OIDCWellKnownURL: discovery.URL,
+		},
+	}
+
+	RegisterOAuthHandlers(cfg)
+
+	if oauthConfig.Endpoint.AuthURL != "https://issuer.example.com/auth" {
+		t.Fatalf("AuthURL = %q, want discovered endpoint", oauthConfig.Endpoint.AuthURL)
+	}
+	if oauthConfig.Endpoint.TokenURL != "https://issuer.example.com/token" {
+		t.Fatalf("TokenURL = %q, want discovered endpoint", oauthConfig.Endpoint.TokenURL)
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/login", nil)
+	req.RemoteAddr = "192.0.2.1:1234"
+	rr := httptest.NewRecorder()
+	http.DefaultServeMux.ServeHTTP(rr, req)
+	loc := rr.Header().Get("Location")
+	if !strings.HasPrefix(loc, "https://issuer.example.com/auth?") {
+		t.Fatalf("login redirect Location = %q, want discovered authorization endpoint", loc)
 	}
 }


### PR DESCRIPTION
### Motivation
- The OAuth2 client was being constructed before OIDC discovery ran, so discovered authorization/token endpoints from a provider could be ignored and deployments relying on discovery would not get working endpoints.
- This change ensures the well-known OIDC discovery is performed first so fallback endpoints are populated into the client config.

### Description
- Call `fetchWellKnownOIDCConfig` before building the `oauth2.Config` in `RegisterOAuthHandlers` so discovered `authorization_endpoint` and `token_endpoint` are included when `setupOAuthConfig` runs.
- Build `oauthConfig` after discovery by moving the `oauthConfig = setupOAuthConfig(&cfg.OAuthConfig)` call in `internal/oauth/oauth.go`.
- Add a regression test `TestRegisterOAuthHandlersUsesDiscoveredEndpoints` in `internal/oauth/oauth_test.go` that serves mock discovery and JWKS endpoints, registers handlers, and verifies the `oauthConfig` endpoints and the `/login` redirect point to the discovered authorization endpoint.

### Testing
- Ran `go test ./...` and all tests completed successfully.
- Ran `go test -race ./...` and the race-enabled test run completed successfully.
- The new oauth package test verifying discovered endpoints passed as part of the test suite.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a360fbd774c8330b87d18934fddd938)