### PR TITLE
Harden CI pipeline and fix reliability/security issues

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,3 +1,9 @@
 .git/
 .gitignore
+.claude/
 README.md
+dev.env
+client_secret.txt
+docker-compose.yml
+deployment/
+test/

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,7 +5,17 @@
 
 version: 2
 updates:
-  - package-ecosystem: "gomod" # See documentation for possible values
-    directory: "/" # Location of package manifests
+  - package-ecosystem: gomod
+    directory: /
     schedule:
-      interval: "weekly"
+      interval: weekly
+
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+
+  - package-ecosystem: docker
+    directory: /
+    schedule:
+      interval: weekly

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,33 +9,75 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 env:
   IMAGE_NAME: jtgasper3/swarm-visualizer
 
 jobs:
-  build:
-    runs-on: ubuntu-latest
+  test:
+    runs-on: ubuntu-24.04
 
     steps:
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - name: Set up Go
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+        with:
+          go-version-file: go.mod
+
+      - name: Run tests
+        run: go test ./...
+
+      - name: Run vet
+        run: go vet ./...
+
+      - name: Run govulncheck
+        run: |
+          go install golang.org/x/vuln/cmd/govulncheck@latest
+          govulncheck ./...
+
+  build:
+    needs: test
+    runs-on: ubuntu-24.04
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
       - name: Login to Docker Hub
-        uses: docker/login-action@v3
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
         if: github.actor != 'dependabot[bot]' && github.actor != 'dependabot-preview[bot]'
         with:
           username: ${{ vars.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@06116385d9baf250c9f4dcb4858b16962ea869c3 # v4.1.0
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
 
       - name: Get Git commit timestamps
         run: echo "TIMESTAMP=$(git log -1 --pretty=%ct)" >> $GITHUB_ENV
 
+      - name: Scan for vulnerabilities
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
+        with:
+          scan-type: fs
+          scan-ref: .
+          format: table
+          exit-code: '1'
+          ignore-unfixed: true
+          vuln-type: os,library
+          severity: CRITICAL,HIGH
+
       - name: Extract metadata
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@80c7e94dd9b9319bd5eb7a0e0fe9291e23a2a2e9 # v6.1.0
         with:
           images: ${{ env.IMAGE_NAME }}
           tags: |
@@ -46,11 +88,15 @@ jobs:
             type=semver,pattern={{major}}.{{minor}}
 
       - name: Build and push image
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7.2.0
         with:
+          context: .
           platforms: linux/amd64,linux/arm64
           push: ${{ github.event_name != 'pull_request' && github.actor != 'dependabot[bot]' && github.actor != 'dependabot-preview[bot]' }}
           tags: ${{ steps.meta.outputs.tags }}
           sbom: true
+          provenance: true
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
         env:
           SOURCE_DATE_EPOCH: ${{ env.TIMESTAMP }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Use the official Golang image as the build stage
-FROM golang:1.26 AS builder
+FROM golang:1.26@sha256:792443b89f65105abba56b9bd5e97f680a80074ac62fc844a584212f8c8102c3 AS builder
 
 WORKDIR /app
 

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -26,7 +26,11 @@ func main() {
 	docker.RegisterDockerHandlers(cfg)
 	oauth.RegisterOAuthHandlers(cfg)
 
-	server := &http.Server{Addr: ":" + cfg.ListenerPort}
+	server := &http.Server{
+		Addr:              ":" + cfg.ListenerPort,
+		ReadHeaderTimeout: 10 * time.Second,
+		WriteTimeout:      90 * time.Second,
+	}
 
 	go func() {
 		log.Printf("Server started on :%s", cfg.ListenerPort)

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/jtgasper3/swarm-visualizer
 
-go 1.25.0
+go 1.26.4
 
 require (
 	github.com/golang-jwt/jwt/v5 v5.3.1

--- a/internal/docker/handlers.go
+++ b/internal/docker/handlers.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"net/url"
 	"sync"
+	"time"
 
 	"github.com/gorilla/websocket"
 
@@ -27,9 +28,11 @@ var (
 			return u.Host == r.Host
 		},
 	}
-	clients = make(map[*websocket.Conn]bool)
-	mu      sync.Mutex
+	clients   = make(map[*websocket.Conn]bool)
+	mu        sync.Mutex
 )
+
+const wsWriteTimeout = 5 * time.Second
 
 func RegisterDockerHandlers(cfg *config.Config) {
 	go inspectSwarmServices(cfg)
@@ -99,6 +102,7 @@ func handleBroadcasts() {
 }
 
 func writeMessage(client *websocket.Conn, msg []byte) error {
+	client.SetWriteDeadline(time.Now().Add(wsWriteTimeout))
 	err := client.WriteMessage(websocket.TextMessage, msg)
 	if err != nil {
 		log.Printf("Write error; closing: %s, %v", client.RemoteAddr(), err)

--- a/internal/docker/inspect.go
+++ b/internal/docker/inspect.go
@@ -33,7 +33,7 @@ type cachedTask struct {
 }
 
 var (
-	broadcast = make(chan []byte)
+	broadcast = make(chan []byte, 1)
 	// lastBroadcastedData is read by WebSocket handler goroutines while the
 	// single inspectSwarmServices goroutine swaps it, so access is atomic.
 	lastBroadcastedData atomic.Pointer[SwarmData]


### PR DESCRIPTION
## Summary

- **Bug fix**: Added missing `actions/checkout` — without it `git log` failed and the Docker build context was empty
- **CI**: Split workflow into `test` + `build` jobs; `build` is gated on tests passing; added `go test`, `go vet`, `govulncheck`, and Trivy filesystem scan
- **Security**: Pinned all GitHub Actions to full commit SHAs and upgraded to latest major versions; added `github-actions` and `docker` Dependabot ecosystems; pinned `golang:1.26` base image to digest
- **Reliability**: Added concurrency group (cancel-in-progress), GHA Docker layer cache, provenance attestation, pinned runner to `ubuntu-24.04`
- **Security**: Expanded `.dockerignore` to exclude `client_secret.txt`, `dev.env`, `.claude/`, `deployment/`, and `test/` — previously a local `docker build` would bake those into the builder layer
- **Security/Reliability**: Added `ReadHeaderTimeout` and `WriteTimeout` to the HTTP server (Slowloris mitigation)
- **Reliability**: Buffered the broadcast channel and added a WebSocket write deadline so a single slow client can't stall updates for all connected clients

## Test plan

- [ ] CI passes on this PR (test job runs `go test`/`go vet`/`govulncheck`; build job runs Trivy then builds multi-platform image)
- [ ] Confirm no image is pushed to Docker Hub for this PR (push condition guards against it)
- [ ] Verify Dependabot opens PRs for `github-actions` and `docker` ecosystems after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)