### PR TITLE
Fix HIDE_LABELS env var and reconcile label categories

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -128,7 +128,7 @@ func LoadConfig() *Config {
 		HideAllEnvs:        os.Getenv("HIDE_ALL_ENVS") == "true",
 		HideAllMounts:      os.Getenv("HIDE_ALL_MOUNTS") == "true",
 		HideAllSecrets:     os.Getenv("HIDE_ALL_SECRETS") == "true",
-		HideLabels:         strings.Split(os.Getenv("HIDE_ALL_LABELS"), ","),
+		HideLabels:         strings.Split(os.Getenv("HIDE_LABELS"), ","),
 		SensitiveDataPaths: sensitiveDataPaths,
 	}
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -69,9 +69,7 @@ func LoadConfig() *Config {
 		"tasks.*.Spec.ContainerSpec.Mounts.*.Source",
 	}
 
-	if sensitiveDataPathsEnv := os.Getenv("SENSITIVE_DATA_PATHS"); sensitiveDataPathsEnv != "" {
-		sensitiveDataPaths = append(sensitiveDataPaths, strings.Split(sensitiveDataPathsEnv, ",")...)
-	}
+	sensitiveDataPaths = append(sensitiveDataPaths, splitList(os.Getenv("SENSITIVE_DATA_PATHS"))...)
 
 	sessionMaxAge := defaultSessionMaxAge
 	if s := os.Getenv("OIDC_SESSION_MAX_AGE"); s != "" {
@@ -116,7 +114,7 @@ func LoadConfig() *Config {
 			ClientID:         os.Getenv("OIDC_CLIENT_ID"),
 			ClientSecret:     strings.TrimSpace(clientSecret),
 			RedirectURL:      os.Getenv("OIDC_REDIRECT_URL"),
-			Scopes:           strings.Split(os.Getenv("OIDC_SCOPES"), ","),
+			Scopes:           splitList(os.Getenv("OIDC_SCOPES")),
 			AuthURL:          os.Getenv("OIDC_AUTH_URL"),
 			TokenURL:         os.Getenv("OIDC_TOKEN_URL"),
 			OIDCWellKnownURL: os.Getenv("OIDC_WELL_KNOWN_URL"),
@@ -128,7 +126,7 @@ func LoadConfig() *Config {
 		HideAllEnvs:        os.Getenv("HIDE_ALL_ENVS") == "true",
 		HideAllMounts:      os.Getenv("HIDE_ALL_MOUNTS") == "true",
 		HideAllSecrets:     os.Getenv("HIDE_ALL_SECRETS") == "true",
-		HideLabels:         strings.Split(os.Getenv("HIDE_LABELS"), ","),
+		HideLabels:         splitList(os.Getenv("HIDE_LABELS")),
 		SensitiveDataPaths: sensitiveDataPaths,
 	}
 }
@@ -155,4 +153,17 @@ func getEnv(key, defaultValue string) string {
 		return defaultValue
 	}
 	return value
+}
+
+// splitList parses a comma-separated value into a slice, trimming whitespace
+// and dropping empty entries. An empty or all-whitespace input yields nil
+// rather than a one-element slice containing an empty string.
+func splitList(value string) []string {
+	var out []string
+	for _, item := range strings.Split(value, ",") {
+		if item = strings.TrimSpace(item); item != "" {
+			out = append(out, item)
+		}
+	}
+	return out
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -99,6 +99,34 @@ func TestLoadConfig_TrustedProxies(t *testing.T) {
 	}
 }
 
+// TestSplitList verifies comma-list parsing trims entries and drops empties.
+func TestSplitList(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  []string
+	}{
+		{name: "empty yields nil", input: "", want: nil},
+		{name: "whitespace only yields nil", input: "  ,  ,", want: nil},
+		{name: "single value", input: "node", want: []string{"node"}},
+		{name: "trims and drops empties", input: " node , , service ", want: []string{"node", "service"}},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := splitList(tc.input)
+			if len(got) != len(tc.want) {
+				t.Fatalf("splitList(%q) = %#v, want %#v", tc.input, got, tc.want)
+			}
+			for i := range got {
+				if got[i] != tc.want[i] {
+					t.Fatalf("splitList(%q) = %#v, want %#v", tc.input, got, tc.want)
+				}
+			}
+		})
+	}
+}
+
 // TestLoadConfig_SessionMaxAge verifies OIDC_SESSION_MAX_AGE parsing.
 func TestLoadConfig_SessionMaxAge(t *testing.T) {
 	tests := []struct {

--- a/internal/docker/inspect.go
+++ b/internal/docker/inspect.go
@@ -237,6 +237,8 @@ func sanitizeServices(services []swarm.Service, cfg *config.Config) []swarm.Serv
 		}
 		if slices.Contains(cfg.HideLabels, "all") || slices.Contains(cfg.HideLabels, "service") {
 			svc.Spec.Labels = nil
+		}
+		if slices.Contains(cfg.HideLabels, "all") || slices.Contains(cfg.HideLabels, "container") {
 			svc.Spec.TaskTemplate.ContainerSpec.Labels = nil
 		}
 
@@ -320,7 +322,7 @@ func sanitizeTasks(tasks []swarm.Task, cfg *config.Config) []swarm.Task {
 		if cfg.HideAllSecrets {
 			t.Spec.ContainerSpec.Secrets = nil
 		}
-		if slices.Contains(cfg.HideLabels, "all") || slices.Contains(cfg.HideLabels, "task") {
+		if slices.Contains(cfg.HideLabels, "all") || slices.Contains(cfg.HideLabels, "container") {
 			t.Spec.ContainerSpec.Labels = nil
 		}
 	}

--- a/internal/docker/inspect_test.go
+++ b/internal/docker/inspect_test.go
@@ -106,6 +106,63 @@ func TestSanitizeServices_HideLabels(t *testing.T) {
 	}
 }
 
+func TestSanitizeServices_HideLabelsCategory(t *testing.T) {
+	newSvc := func() swarm.Service {
+		return swarm.Service{
+			Spec: swarm.ServiceSpec{
+				TaskTemplate: swarm.TaskSpec{
+					ContainerSpec: &swarm.ContainerSpec{
+						Labels: map[string]string{"c": "v"},
+					},
+				},
+				Annotations: swarm.Annotations{Labels: map[string]string{"s": "v"}},
+			},
+		}
+	}
+
+	// "service" hides service-level labels but leaves container labels.
+	out := sanitizeServices([]swarm.Service{newSvc()}, &config.Config{HideLabels: []string{"service"}})
+	if out[0].Spec.Labels != nil {
+		t.Fatalf("expected service labels to be nil, got: %#v", out[0].Spec.Labels)
+	}
+	if out[0].Spec.TaskTemplate.ContainerSpec.Labels == nil {
+		t.Fatalf("expected container labels to be retained under 'service'")
+	}
+
+	// "container" hides container labels but leaves service-level labels.
+	out = sanitizeServices([]swarm.Service{newSvc()}, &config.Config{HideLabels: []string{"container"}})
+	if out[0].Spec.TaskTemplate.ContainerSpec.Labels != nil {
+		t.Fatalf("expected container labels to be nil, got: %#v", out[0].Spec.TaskTemplate.ContainerSpec.Labels)
+	}
+	if out[0].Spec.Labels == nil {
+		t.Fatalf("expected service labels to be retained under 'container'")
+	}
+
+	// "all" hides both.
+	out = sanitizeServices([]swarm.Service{newSvc()}, &config.Config{HideLabels: []string{"all"}})
+	if out[0].Spec.Labels != nil || out[0].Spec.TaskTemplate.ContainerSpec.Labels != nil {
+		t.Fatalf("expected all labels to be nil under 'all'")
+	}
+}
+
+func TestSanitizeTasks_HideLabelsCategory(t *testing.T) {
+	newTask := func() swarm.Task {
+		return swarm.Task{Spec: swarm.TaskSpec{ContainerSpec: &swarm.ContainerSpec{Labels: map[string]string{"c": "v"}}}}
+	}
+
+	// "container" hides task container labels.
+	out := sanitizeTasks([]swarm.Task{newTask()}, &config.Config{HideLabels: []string{"container"}})
+	if out[0].Spec.ContainerSpec.Labels != nil {
+		t.Fatalf("expected task container labels to be nil, got: %#v", out[0].Spec.ContainerSpec.Labels)
+	}
+
+	// "task" is no longer a recognized category and must be a no-op.
+	out = sanitizeTasks([]swarm.Task{newTask()}, &config.Config{HideLabels: []string{"task"}})
+	if out[0].Spec.ContainerSpec.Labels == nil {
+		t.Fatalf("expected task container labels to be retained for unrecognized 'task' category")
+	}
+}
+
 func TestSanitizeTasks_HideAllEnvs(t *testing.T) {
 	tsk := swarm.Task{Spec: swarm.TaskSpec{ContainerSpec: &swarm.ContainerSpec{Env: []string{"A=1"}, Labels: map[string]string{"l": "v"}}}}
 	out := sanitizeTasks([]swarm.Task{tsk}, &config.Config{HideAllEnvs: true})


### PR DESCRIPTION
Cleanups around the `HIDE_LABELS` configuration, from an end-to-end review.

- **Rename `HIDE_ALL_LABELS` → `HIDE_LABELS`.** The documented var was never read; the code read `HIDE_ALL_LABELS`, so following the README silently hid nothing.
- **Reconcile label categories** with the documented set (`all, container, network, node, service`): container-spec labels are now governed by `container` everywhere (services and tasks). Previously `service` hid both service- and container-spec labels and task container labels were gated by an undocumented `task`.
- **Normalize comma-list env parsing** with a `splitList` helper that trims and drops empties, so `OIDC_SCOPES`/`HIDE_LABELS`/`SENSITIVE_DATA_PATHS` yield `nil` instead of `[""]` when unset.

Tests added for the category behavior and `splitList`. `go test ./...` green.

Note: behavior change — anyone relying on the (only-working) `HIDE_ALL_LABELS=service` to also strip container labels now needs `container` (or `all`). Given the documented var never worked, real-world impact is minimal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)