### PR TITLE
Add OIDC nonce validation and a logout endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,8 @@ OIDC Environment Variables:
 - `OIDC_USERNAME_CLAIM`: JWT claim to use as the display username (default: `preferred_username`)
 - `OIDC_SESSION_MAX_AGE`: lifetime of the session cookie in seconds (default: `3600`)
 
+The login flow protects against CSRF with a `state` parameter and against token replay with a `nonce` (validated against the ID token's `nonce` claim in the callback). When authentication is enabled the app exposes a `<CONTEXT_ROOT>logout` endpoint (and a logout button in the UI) that clears the local session cookie. This is a *local* logout only — it does not call the identity provider's end-session endpoint, so an existing IdP session may sign the user straight back in.
+
 Other Environment Variables:
 
 - `DOCKER_API_VERSION`: adjust the Docker api version if the server needs it. (default: `(negotiated)`)

--- a/internal/docker/inspect.go
+++ b/internal/docker/inspect.go
@@ -21,6 +21,7 @@ import (
 
 type SwarmData struct {
 	ClusterName string            `json:"clusterName"`
+	AuthEnabled bool              `json:"authEnabled"`
 	Networks    []network.Summary `json:"networks"`
 	Nodes       []swarm.Node      `json:"nodes"`
 	Services    []swarm.Service   `json:"services"`
@@ -64,6 +65,7 @@ func inspectSwarmServices(cfg *config.Config) {
 
 		data := SwarmData{
 			ClusterName: cfg.ClusterName,
+			AuthEnabled: cfg.AuthEnabled,
 			Services:    services,
 			Nodes:       nodes,
 			Networks:    networks,

--- a/internal/oauth/callback_test.go
+++ b/internal/oauth/callback_test.go
@@ -1,0 +1,160 @@
+package oauth
+
+import (
+	"crypto/rand"
+	"crypto/rsa"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+	"time"
+
+	"github.com/golang-jwt/jwt/v5"
+	"github.com/jtgasper3/swarm-visualizer/internal/config"
+	"golang.org/x/oauth2"
+)
+
+func TestHandleLogin_SetsStateAndNonce(t *testing.T) {
+	orig := oauthConfig
+	t.Cleanup(func() { oauthConfig = orig })
+	oauthConfig = &oauth2.Config{
+		ClientID:    "client-1",
+		RedirectURL: "https://app.example.com/callback",
+		Endpoint:    oauth2.Endpoint{AuthURL: "https://issuer.example.com/auth"},
+	}
+
+	cfg := &config.Config{ContextRoot: "/"}
+	req := httptest.NewRequest(http.MethodGet, "/login", nil)
+	rr := httptest.NewRecorder()
+
+	handleLogin(cfg, rr, req)
+
+	if rr.Code != http.StatusTemporaryRedirect {
+		t.Fatalf("status = %d, want %d", rr.Code, http.StatusTemporaryRedirect)
+	}
+	loc, err := url.Parse(rr.Header().Get("Location"))
+	if err != nil {
+		t.Fatalf("parse redirect: %v", err)
+	}
+	stateParam := loc.Query().Get("state")
+	nonceParam := loc.Query().Get("nonce")
+	if stateParam == "" || nonceParam == "" {
+		t.Fatalf("expected state and nonce in auth URL, got %q", loc.RawQuery)
+	}
+
+	cookies := map[string]string{}
+	for _, c := range rr.Result().Cookies() {
+		cookies[c.Name] = c.Value
+	}
+	if cookies["state"] != stateParam {
+		t.Errorf("state cookie %q != state param %q", cookies["state"], stateParam)
+	}
+	if cookies["nonce"] != nonceParam {
+		t.Errorf("nonce cookie %q != nonce param %q", cookies["nonce"], nonceParam)
+	}
+}
+
+func TestHandleCallback_NonceValidation(t *testing.T) {
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatalf("generate key: %v", err)
+	}
+	const kid, issuer, client = "kid1", "https://issuer.example.com", "client-1"
+
+	origKeys, origCfg := signingKeys, oauthConfig
+	t.Cleanup(func() { signingKeys = origKeys; oauthConfig = origCfg })
+	signingKeys = &keyStore{
+		keys:        map[string]*rsa.PublicKey{kid: &key.PublicKey},
+		lastRefresh: time.Now(),
+	}
+
+	signIDToken := func(nonce string) string {
+		tok := jwt.NewWithClaims(jwt.SigningMethodRS256, jwt.MapClaims{
+			"iss":   issuer,
+			"aud":   client,
+			"sub":   "user-1",
+			"exp":   time.Now().Add(time.Hour).Unix(),
+			"iat":   time.Now().Unix(),
+			"nonce": nonce,
+		})
+		tok.Header["kid"] = kid
+		s, err := tok.SignedString(key)
+		if err != nil {
+			t.Fatalf("sign id_token: %v", err)
+		}
+		return s
+	}
+
+	cfg := &config.Config{ContextRoot: "/", OAuthConfig: config.OAuthConfig{ClientID: client, Issuer: issuer}}
+
+	doCallback := func(t *testing.T, tokenNonce, cookieNonce string) *httptest.ResponseRecorder {
+		idToken := signIDToken(tokenNonce)
+		tokenSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"access_token":"at","token_type":"Bearer","id_token":"` + idToken + `"}`))
+		}))
+		defer tokenSrv.Close()
+
+		oauthConfig = &oauth2.Config{
+			ClientID: client,
+			Endpoint: oauth2.Endpoint{TokenURL: tokenSrv.URL, AuthURL: "https://issuer.example.com/auth"},
+		}
+
+		req := httptest.NewRequest(http.MethodGet, "/callback?code=abc&state=xyz", nil)
+		req.AddCookie(&http.Cookie{Name: "state", Value: "xyz"})
+		req.AddCookie(&http.Cookie{Name: "nonce", Value: cookieNonce})
+		rr := httptest.NewRecorder()
+		handleCallback(cfg, rr, req)
+		return rr
+	}
+
+	idTokenCookie := func(rr *httptest.ResponseRecorder) string {
+		for _, c := range rr.Result().Cookies() {
+			if c.Name == "id_token" {
+				return c.Value
+			}
+		}
+		return ""
+	}
+
+	t.Run("matching nonce establishes the session", func(t *testing.T) {
+		rr := doCallback(t, "nonce-abc", "nonce-abc")
+		if rr.Code != http.StatusTemporaryRedirect {
+			t.Fatalf("status = %d, want redirect; body=%s", rr.Code, rr.Body.String())
+		}
+		if idTokenCookie(rr) == "" {
+			t.Fatal("expected id_token cookie to be set")
+		}
+	})
+
+	t.Run("mismatched nonce is rejected", func(t *testing.T) {
+		rr := doCallback(t, "nonce-abc", "nonce-different")
+		if rr.Code != http.StatusBadRequest {
+			t.Fatalf("status = %d, want %d", rr.Code, http.StatusBadRequest)
+		}
+		if v := idTokenCookie(rr); v != "" {
+			t.Fatalf("id_token must not be set on nonce mismatch, got %q", v)
+		}
+	})
+}
+
+func TestHandleLogout_ClearsSession(t *testing.T) {
+	cfg := &config.Config{ContextRoot: "/"}
+	req := httptest.NewRequest(http.MethodGet, "/logout", nil)
+	rr := httptest.NewRecorder()
+
+	handleLogout(cfg, rr, req)
+
+	if rr.Code != http.StatusTemporaryRedirect {
+		t.Fatalf("status = %d, want %d", rr.Code, http.StatusTemporaryRedirect)
+	}
+	cleared := false
+	for _, c := range rr.Result().Cookies() {
+		if c.Name == "id_token" && c.Value == "" && c.MaxAge < 0 {
+			cleared = true
+		}
+	}
+	if !cleared {
+		t.Fatal("expected id_token cookie to be cleared")
+	}
+}

--- a/internal/oauth/idtoken.go
+++ b/internal/oauth/idtoken.go
@@ -23,6 +23,13 @@ func ValidateToken(cfg *config.Config, r *http.Request) (jwt.MapClaims, error) {
 		rawIDToken = cookie.Value
 	}
 
+	return validateRawToken(cfg, rawIDToken)
+}
+
+// validateRawToken verifies an ID token's signature, issuer, and audience and
+// returns its claims. It is shared by the WebSocket request path and the OAuth
+// callback (which additionally checks the nonce).
+func validateRawToken(cfg *config.Config, rawIDToken string) (jwt.MapClaims, error) {
 	token, err := jwt.Parse(rawIDToken, func(token *jwt.Token) (interface{}, error) {
 		if _, ok := token.Method.(*jwt.SigningMethodRSA); !ok {
 			return nil, fmt.Errorf("unexpected signing method: %v", token.Header["alg"])

--- a/internal/oauth/oauth.go
+++ b/internal/oauth/oauth.go
@@ -3,6 +3,7 @@ package oauth
 import (
 	"context"
 	"crypto/rand"
+	"crypto/subtle"
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
@@ -113,6 +114,9 @@ func RegisterOAuthHandlers(cfg *config.Config) {
 			}
 			handleCallback(cfg, w, r)
 		})
+		http.HandleFunc(cfg.ContextRoot+"logout", func(w http.ResponseWriter, r *http.Request) {
+			handleLogout(cfg, w, r)
+		})
 	}
 }
 
@@ -135,23 +139,25 @@ func handleLogin(cfg *config.Config, w http.ResponseWriter, r *http.Request) {
 		http.Error(w, fmt.Sprintf("Failed to generate state: %v", err), http.StatusInternalServerError)
 		return
 	}
+	nonce, err := generateSecureRandomString(32)
+	if err != nil {
+		http.Error(w, fmt.Sprintf("Failed to generate nonce: %v", err), http.StatusInternalServerError)
+		return
+	}
 
-	url := oauthConfig.AuthCodeURL(state)
-	http.SetCookie(w, &http.Cookie{
-		Name:     "nonce",
-		Value:    state,
-		Path:     cfg.ContextRoot,
-		HttpOnly: true,
-		Secure:   true,
-		SameSite: http.SameSiteLaxMode,
-	})
+	// state binds the callback to this browser (CSRF); nonce binds the issued
+	// ID token to this login flow (replay protection) and is validated against
+	// the token's nonce claim in the callback.
+	url := oauthConfig.AuthCodeURL(state, oauth2.SetAuthURLParam("nonce", nonce))
+	setFlowCookie(cfg, w, "state", state)
+	setFlowCookie(cfg, w, "nonce", nonce)
 	http.Redirect(w, r, url, http.StatusTemporaryRedirect)
 }
 
 func handleCallback(cfg *config.Config, w http.ResponseWriter, r *http.Request) {
-	nonceCookie, err := r.Cookie("nonce")
-	if err != nil || nonceCookie.Value != r.URL.Query().Get("state") {
-		clearNonceCookie(cfg, w)
+	stateCookie, err := r.Cookie("state")
+	if err != nil || subtle.ConstantTimeCompare([]byte(stateCookie.Value), []byte(r.URL.Query().Get("state"))) != 1 {
+		clearFlowCookies(cfg, w)
 		http.Error(w, "Invalid state", http.StatusBadRequest)
 		return
 	}
@@ -159,17 +165,42 @@ func handleCallback(cfg *config.Config, w http.ResponseWriter, r *http.Request) 
 	code := r.URL.Query().Get("code")
 	token, err := oauthConfig.Exchange(context.Background(), code)
 	if err != nil {
+		clearFlowCookies(cfg, w)
 		http.Error(w, fmt.Sprintf("Failed to exchange token: %v", err), http.StatusInternalServerError)
 		return
 	}
 
 	rawIDToken, ok := token.Extra("id_token").(string)
 	if !ok {
+		clearFlowCookies(cfg, w)
 		http.Error(w, "No id_token found", http.StatusInternalServerError)
 		return
 	}
 
-	clearNonceCookie(cfg, w)
+	// Validate the ID token and bind it to this login flow via the nonce, so a
+	// token captured or replayed from a different flow cannot be used here.
+	claims, err := validateRawToken(cfg, rawIDToken)
+	if err != nil {
+		clearFlowCookies(cfg, w)
+		log.Printf("Callback ID token validation failed: %s %v", r.RemoteAddr, err)
+		http.Error(w, "Invalid ID token", http.StatusUnauthorized)
+		return
+	}
+	nonceCookie, err := r.Cookie("nonce")
+	if err != nil {
+		clearFlowCookies(cfg, w)
+		http.Error(w, "Missing nonce", http.StatusBadRequest)
+		return
+	}
+	tokenNonce, _ := claims["nonce"].(string)
+	if tokenNonce == "" || subtle.ConstantTimeCompare([]byte(tokenNonce), []byte(nonceCookie.Value)) != 1 {
+		clearFlowCookies(cfg, w)
+		log.Printf("Callback nonce mismatch: %s", r.RemoteAddr)
+		http.Error(w, "Invalid nonce", http.StatusBadRequest)
+		return
+	}
+
+	clearFlowCookies(cfg, w)
 
 	http.SetCookie(w, &http.Cookie{
 		Name:     "id_token",
@@ -231,16 +262,51 @@ func fetchWellKnownOIDCConfig(cfg *config.Config) error {
 	return nil
 }
 
-func clearNonceCookie(cfg *config.Config, w http.ResponseWriter) {
+// handleLogout clears the session cookie and returns the user to the app,
+// which will then prompt for login again. This is a local logout; it does not
+// terminate the session at the identity provider.
+func handleLogout(cfg *config.Config, w http.ResponseWriter, r *http.Request) {
 	http.SetCookie(w, &http.Cookie{
-		Name:     "nonce",
+		Name:     "id_token",
 		Value:    "",
 		Path:     cfg.ContextRoot,
 		HttpOnly: true,
 		Secure:   true,
+		SameSite: http.SameSiteStrictMode,
 		Expires:  time.Unix(0, 0),
 		MaxAge:   -1,
 	})
+	http.Redirect(w, r, cfg.ContextRoot, http.StatusTemporaryRedirect)
+}
+
+// setFlowCookie sets a short-lived cookie used during the OAuth redirect flow.
+// SameSite=Lax so it survives the top-level redirect back from the identity
+// provider.
+func setFlowCookie(cfg *config.Config, w http.ResponseWriter, name, value string) {
+	http.SetCookie(w, &http.Cookie{
+		Name:     name,
+		Value:    value,
+		Path:     cfg.ContextRoot,
+		HttpOnly: true,
+		Secure:   true,
+		SameSite: http.SameSiteLaxMode,
+	})
+}
+
+// clearFlowCookies expires the state and nonce cookies set during login.
+func clearFlowCookies(cfg *config.Config, w http.ResponseWriter) {
+	for _, name := range []string{"state", "nonce"} {
+		http.SetCookie(w, &http.Cookie{
+			Name:     name,
+			Value:    "",
+			Path:     cfg.ContextRoot,
+			HttpOnly: true,
+			Secure:   true,
+			SameSite: http.SameSiteLaxMode,
+			Expires:  time.Unix(0, 0),
+			MaxAge:   -1,
+		})
+	}
 }
 
 func generateSecureRandomString(length int) (string, error) {

--- a/web/static/index.html
+++ b/web/static/index.html
@@ -52,6 +52,7 @@
 
         <template #append>
             <div class="ga-2 align-center">
+              <v-btn v-if="authEnabled" icon="mdi-logout" title="Log out" aria-label="Log out" @click="logout()"></v-btn>
               <!-- <v-btn color="medium-emphasis" icon="mdi-email-outline">
                 <v-badge color="error" content="1" dot>
                   <v-icon />
@@ -264,6 +265,7 @@
     createApp({
       setup() {
         const clusterName = shallowRef('');
+        const authEnabled = shallowRef(false);
         const drawer = useStorage('drawer', true);
         const wsState = shallowRef('connecting');
         const filters = useStorage('filters.4', {
@@ -366,6 +368,10 @@
           window.location.href = window.location.pathname + 'login';
         }
 
+        function logout() {
+          window.location.href = window.location.pathname + 'logout';
+        }
+
         function selectNetworks(option) {
           if (option === 'all') {
             const uniqueItems = networks.value.filter(network => !filters.value.networksSelection.includes(network.Id)).map((network => network.Id))
@@ -417,6 +423,7 @@
 
         function updateReceivedData(data) {
           clusterName.value = data.clusterName;
+          authEnabled.value = data.authEnabled;
 
           networks.value = data.networks;
 
@@ -498,6 +505,7 @@
 
         return {
           clusterName,
+          authEnabled,
           drawer,
           wsState,
           vuetifyDefaults,
@@ -513,6 +521,7 @@
           sortedServicesGroups,
           createServiceName,
           getAuthorized,
+          logout,
           selectNetworks,
           selectNodes,
           selectServices,


### PR DESCRIPTION
Two OIDC gaps from the review.

**#7 — Nonce validation.** The login flow only sent a `state` parameter (CSRF) and never validated an OIDC nonce, nor validated the ID token at the callback. `handleLogin` now issues a separate random nonce and stores it in its own cookie; `handleCallback` validates the returned ID token (signature/iss/aud, reused from the WebSocket path) and constant-time compares its `nonce` claim against the cookie. The CSRF cookie is also renamed from the misleading `nonce` to `state`.

**#8 — Logout.** New `<context-root>logout` endpoint that expires the `id_token` cookie and redirects to the app. The frontend shows a logout button when auth is enabled (signalled via a new `authEnabled` field on the broadcast payload). Local logout only — it does not call the IdP end-session endpoint.

Tests added: login issues state+nonce, callback accepts matching / rejects mismatched nonce, logout clears the cookie. `go test ./...` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)