### PR TITLE
Quick wins: health endpoint, token-exchange timeout, cleanups

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,20 +10,24 @@ RUN go mod download
 # Copy the rest of the source code and build
 COPY . .
 RUN CGO_ENABLED=0 GOOS=linux go build -o swarm-monitor ./cmd/server
+RUN CGO_ENABLED=0 GOOS=linux go build -o healthcheck ./cmd/healthcheck
 
 # Use a minimal base image for the final stage
 FROM scratch
 
 WORKDIR /
 
-# Copy the binary from the build stage
+# Copy the binaries from the build stage
 COPY --from=builder /app/swarm-monitor /swarm-monitor
+COPY --from=builder /app/healthcheck /healthcheck
 COPY /web/static/ /static
 
 COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
 ENV SSL_CERT_FILE=/etc/ssl/certs/ca-certificates.crt
 
-# Expose port the default port 8080m but can be overridden
+# Expose the default port 8080, but it can be overridden
 EXPOSE 8080
+
+HEALTHCHECK --interval=30s --timeout=5s --start-period=15s --retries=3 CMD ["/healthcheck"]
 
 CMD ["/swarm-monitor"]

--- a/README.md
+++ b/README.md
@@ -147,6 +147,32 @@ networks:
 
 With this setup the application can no longer issue write commands to the daemon, so a compromise of the app cannot be escalated into control of the cluster.
 
+#### Run as a non-root user (optional hardening)
+
+The image runs as **root** by default so the simple, directly-mounted `/var/run/docker.sock` examples work out of the box (the socket is normally restricted to root or the host `docker` group). The app only ever reads the Docker API, so for defence-in-depth you can run it as a non-root user with `--user`.
+
+With the read-only socket proxy above the app never touches the host socket, so any uid works with no extra configuration:
+
+```yaml
+viz:
+  image: jtgasper3/swarm-visualizer:latest
+  user: "65534:65534"
+  environment:
+    DOCKER_HOST: tcp://dockerproxy:2375
+```
+
+If you run non-root **and** mount the socket directly, the process must also be in the socket's group or it gets `permission denied`. The gid is `0` on Docker Desktop (the socket is `root:root`) and usually the host `docker` group on Linux (`stat -c '%g' /var/run/docker.sock`):
+
+```yaml
+viz:
+  image: jtgasper3/swarm-visualizer:latest
+  user: "65534:65534"
+  group_add:
+    - "0"
+  volumes:
+    - /var/run/docker.sock:/var/run/docker.sock
+```
+
 ### Authentication is not authorization
 
 Setting `ENABLE_AUTHN=true` enables *authentication* only: it verifies that a request carries a valid, unexpired ID token issued by your configured identity provider for this client (the token's signature, `aud`, and `iss` are checked). It does **not** perform *authorization* — there is no per-user, group, or role check. **Any identity your IdP will issue such a token to can view the dashboard.**

--- a/cmd/healthcheck/main.go
+++ b/cmd/healthcheck/main.go
@@ -1,0 +1,32 @@
+// Command healthcheck is a tiny client used as the container HEALTHCHECK. The
+// final image is built FROM scratch, which has no shell or curl/wget, so this
+// compiled helper performs the probe instead. It exits 0 when /healthz returns
+// 200 and non-zero otherwise.
+package main
+
+import (
+	"fmt"
+	"net/http"
+	"os"
+	"time"
+)
+
+func main() {
+	port := os.Getenv("LISTENER_PORT")
+	if port == "" {
+		port = "8080"
+	}
+
+	client := &http.Client{Timeout: 4 * time.Second}
+	resp, err := client.Get(fmt.Sprintf("http://127.0.0.1:%s/healthz", port))
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "healthcheck:", err)
+		os.Exit(1)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		fmt.Fprintf(os.Stderr, "healthcheck: unexpected status %d\n", resp.StatusCode)
+		os.Exit(1)
+	}
+}

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -26,6 +26,18 @@ func main() {
 	docker.RegisterDockerHandlers(cfg)
 	oauth.RegisterOAuthHandlers(cfg)
 
+	// Unauthenticated readiness endpoint at a fixed path (independent of
+	// CONTEXT_ROOT) for orchestrator health checks. Reports ready once the
+	// first successful Docker poll has published data.
+	http.HandleFunc("/healthz", func(w http.ResponseWriter, r *http.Request) {
+		if docker.Ready() {
+			w.Header().Set("Content-Type", "text/plain")
+			_, _ = w.Write([]byte("ok"))
+			return
+		}
+		http.Error(w, "not ready", http.StatusServiceUnavailable)
+	})
+
 	server := &http.Server{
 		Addr:              ":" + cfg.ListenerPort,
 		ReadHeaderTimeout: 10 * time.Second,

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -133,22 +133,6 @@ func LoadConfig() *Config {
 	}
 }
 
-// Create function to print out config for debugging purposes
-func (c *Config) PrintConfig() {
-	log.Printf("Cluster Name: %s", c.ClusterName)
-	log.Printf("Context Root: %s", c.ContextRoot)
-	log.Printf("Listener Port: %s", c.ListenerPort)
-	log.Printf("Auth Enabled: %t", c.AuthEnabled)
-	log.Printf("Sensitive Data Paths: %v", c.SensitiveDataPaths)
-	log.Printf("OAuth Client ID: %s", c.OAuthConfig.ClientID)
-	log.Printf("OAuth Redirect URL: %s", c.OAuthConfig.RedirectURL)
-	log.Printf("OAuth Scopes: %v", c.OAuthConfig.Scopes)
-	log.Printf("OAuth Auth URL: %s", c.OAuthConfig.AuthURL)
-	log.Printf("OAuth Token URL: %s", c.OAuthConfig.TokenURL)
-	log.Printf("OAuth OIDC Well Known URL: %s", c.OAuthConfig.OIDCWellKnownURL)
-	log.Printf("OAuth Username Claim: %s", c.OAuthConfig.UsernameClaim)
-}
-
 func getEnv(key, defaultValue string) string {
 	value := os.Getenv(key)
 	if value == "" {

--- a/internal/docker/inspect.go
+++ b/internal/docker/inspect.go
@@ -41,6 +41,13 @@ var (
 	stoppedTaskCache = make(map[string]cachedTask)
 )
 
+// Ready reports whether at least one successful swarm inspection has completed,
+// i.e. the Docker API is reachable and data has been published. It stays true
+// once the first poll succeeds, so it does not flap on transient errors.
+func Ready() bool {
+	return lastBroadcastedData.Load() != nil
+}
+
 func inspectSwarmServices(cfg *config.Config) {
 	sleepDuration := 1 * time.Second
 

--- a/internal/docker/inspect_test.go
+++ b/internal/docker/inspect_test.go
@@ -8,6 +8,21 @@ import (
 	"github.com/moby/moby/api/types/swarm"
 )
 
+func TestReady(t *testing.T) {
+	orig := lastBroadcastedData.Load()
+	t.Cleanup(func() { lastBroadcastedData.Store(orig) })
+
+	lastBroadcastedData.Store(nil)
+	if Ready() {
+		t.Fatal("expected not ready before the first successful poll")
+	}
+
+	lastBroadcastedData.Store(&SwarmData{})
+	if !Ready() {
+		t.Fatal("expected ready once data has been published")
+	}
+}
+
 func TestSanitizeNodes_HideLabels(t *testing.T) {
 	nodes := []swarm.Node{{Spec: swarm.NodeSpec{Annotations: swarm.Annotations{Labels: map[string]string{"secret": "v", "keep": "v2"}}}}}
 	cfg := &config.Config{HideLabels: []string{"node"}}

--- a/internal/oauth/oauth.go
+++ b/internal/oauth/oauth.go
@@ -156,8 +156,13 @@ func handleCallback(cfg *config.Config, w http.ResponseWriter, r *http.Request) 
 		return
 	}
 
+	// Bound the token exchange so a hung or slow IdP token endpoint cannot tie
+	// up the request indefinitely.
+	ctx, cancel := context.WithTimeout(r.Context(), 10*time.Second)
+	defer cancel()
+
 	code := r.URL.Query().Get("code")
-	token, err := oauthConfig.Exchange(context.Background(), code)
+	token, err := oauthConfig.Exchange(ctx, code)
 	if err != nil {
 		http.Error(w, fmt.Sprintf("Failed to exchange token: %v", err), http.StatusInternalServerError)
 		return

--- a/web/static/index.html
+++ b/web/static/index.html
@@ -326,12 +326,12 @@
         const debouncedFilterText = refDebounced(computed(() => filters.value.filterText), 250);
         const debouncedFilters = computed(() => ({ ...filters.value, filterText: debouncedFilterText.value }));
 
-        const sortedNetworks = computed(() => networks.value.sort((a, b) => a.Name.localeCompare(b.Name)));
-        const sortedNodes = computed(() => nodes.value.sort((a, b) => a.Description.Hostname.localeCompare(b.Description.Hostname)));
+        const sortedNetworks = computed(() => [...networks.value].sort((a, b) => a.Name.localeCompare(b.Name)));
+        const sortedNodes = computed(() => [...nodes.value].sort((a, b) => a.Description.Hostname.localeCompare(b.Description.Hostname)));
         const sortedServicesGroups = computed(() => {
           const stackMap = new Map();
           
-          services.value
+          [...services.value]
           .sort((a, b) => a.Spec.Name.localeCompare(b.Spec.Name))
           .forEach(service => {
             const stackName = service.Spec.Labels?.['com.docker.stack.namespace'] || 'default';


### PR DESCRIPTION
A batch of small, self-contained review items.

- **#14 — Health endpoint + HEALTHCHECK.** Unauthenticated `/healthz` (fixed path, independent of `CONTEXT_ROOT`) reporting ready once the first Docker poll publishes data. Since the image is `FROM scratch`, ships a tiny compiled `cmd/healthcheck` helper wired as a container `HEALTHCHECK`.
- **#15 — Non-root documented as optional hardening.** The image keeps running as **root** by default so the simple directly-mounted-socket setup works out of the box; running non-root (trivial with the socket proxy, or `group_add` for a direct mount) is documented. Verified against a live swarm that non-root + direct socket needs the socket group, hence the root default.
- **#11 — Token-exchange timeout.** `handleCallback` bounds the OAuth exchange with a 10s context from the request instead of `context.Background()`.
- **#12 — Remove dead `Config.PrintConfig`.**
- **#16 — Copy arrays before `.sort()`** in the `sortedNetworks`/`sortedNodes`/`sortedServicesGroups` computed props (Vue reactivity anti-pattern).

`go test ./...` green; health path + HEALTHCHECK verified `healthy` on a live swarm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)