### PR TITLE
Tiered polling behind a Docker client interface (#9 + #13 slice)

### DIFF
--- a/internal/docker/handlers.go
+++ b/internal/docker/handlers.go
@@ -74,7 +74,12 @@ type wsClient struct {
 func RegisterDockerHandlers(cfg *config.Config) {
 	maxClients = cfg.MaxWSConnections
 
-	go inspectSwarmServices(cfg)
+	src, err := newMobySource()
+	if err != nil {
+		log.Fatal("Docker client error:", err)
+	}
+
+	go inspectSwarmServices(cfg, src)
 	go handleBroadcasts()
 
 	http.HandleFunc(cfg.ContextRoot+"ws", func(w http.ResponseWriter, r *http.Request) {

--- a/internal/docker/inspect.go
+++ b/internal/docker/inspect.go
@@ -49,25 +49,119 @@ func Ready() bool {
 	return lastBroadcastedData.Load() != nil
 }
 
-func inspectSwarmServices(cfg *config.Config) {
-	sleepDuration := 1 * time.Second
+// swarmSource is the subset of the Docker API the inspector needs. It is an
+// interface so tests can substitute a fake daemon for the real client.
+type swarmSource interface {
+	Nodes(ctx context.Context) ([]swarm.Node, error)
+	Services(ctx context.Context) ([]swarm.Service, error)
+	Tasks(ctx context.Context) ([]swarm.Task, error)
+	Networks(ctx context.Context) ([]network.Summary, error)
+}
 
+// mobySource adapts the real Docker client to swarmSource.
+type mobySource struct{ cli *client.Client }
+
+// newMobySource creates a swarmSource backed by a Docker client configured from
+// the environment.
+func newMobySource() (swarmSource, error) {
 	cli, err := client.NewClientWithOpts(client.FromEnv, client.WithAPIVersionNegotiation())
 	if err != nil {
-		log.Fatal("Docker client error:", err)
+		return nil, err
+	}
+	return mobySource{cli: cli}, nil
+}
+
+func (m mobySource) Nodes(ctx context.Context) ([]swarm.Node, error) {
+	res, err := m.cli.NodeList(ctx, client.NodeListOptions{})
+	if err != nil {
+		return nil, err
+	}
+	return res.Items, nil
+}
+
+func (m mobySource) Services(ctx context.Context) ([]swarm.Service, error) {
+	res, err := m.cli.ServiceList(ctx, client.ServiceListOptions{})
+	if err != nil {
+		return nil, err
+	}
+	return res.Items, nil
+}
+
+func (m mobySource) Tasks(ctx context.Context) ([]swarm.Task, error) {
+	res, err := m.cli.TaskList(ctx, client.TaskListOptions{})
+	if err != nil {
+		return nil, err
+	}
+	return res.Items, nil
+}
+
+func (m mobySource) Networks(ctx context.Context) ([]network.Summary, error) {
+	res, err := m.cli.NetworkList(ctx, client.NetworkListOptions{Filters: make(client.Filters).Add("scope", "swarm")})
+	if err != nil {
+		return nil, err
+	}
+	return res.Items, nil
+}
+
+const (
+	// taskPollInterval is how often task state is refreshed. Tasks change the
+	// most and are not observable via the Docker events API (there is no task
+	// event type), so they are polled at this cadence.
+	taskPollInterval = 1 * time.Second
+	// structuralPollInterval is how often the slower-changing nodes, services,
+	// and networks are refreshed.
+	structuralPollInterval = 5 * time.Second
+)
+
+// inspectSwarmServices polls the swarm and publishes a snapshot whenever it
+// changes. Tasks are polled frequently for freshness; nodes, services, and
+// networks change rarely, so they are polled on a slower cadence. The most
+// recently fetched value for each group is cached between ticks and reassembled
+// on every publish.
+//
+// Reassembly applies SensitiveDataPaths via ClearByPath, which only zeroes
+// fields and is therefore idempotent; re-applying it to a cached (already
+// cleared) slice that is also referenced by the previously published snapshot
+// leaves that snapshot's bytes unchanged, so change detection stays correct.
+func inspectSwarmServices(cfg *config.Config, src swarmSource) {
+	ctx := context.Background()
+
+	var (
+		nodes    []swarm.Node
+		services []swarm.Service
+		networks []network.Summary
+		tasks    []swarm.Task
+
+		haveStructural bool
+		haveTasks      bool
+	)
+
+	refreshStructural := func() bool {
+		n, errN := getNodesInfo(ctx, src, cfg)
+		s, errS := getServicesInfo(ctx, src, cfg)
+		nw, errNw := getNetworksInfo(ctx, src, cfg)
+		if errN != nil || errS != nil || errNw != nil {
+			return false
+		}
+		nodes, services, networks = n, s, nw
+		haveStructural = true
+		return true
 	}
 
-	for {
-		ctx := context.Background()
+	refreshTasks := func() bool {
+		t, err := getTasksInfo(ctx, src, cfg)
+		if err != nil {
+			return false
+		}
+		tasks = t
+		haveTasks = true
+		return true
+	}
 
-		nodes, errNode := getNodesInfo(ctx, cli, cfg)
-		tasks, errTask := getTasksInfo(ctx, cli, cfg)
-		services, errService := getServicesInfo(ctx, cli, cfg)
-		networks, errNetwork := getNetworksInfo(ctx, cli, cfg)
-
-		if errNode != nil || errTask != nil || errService != nil || errNetwork != nil {
-			time.Sleep(sleepDuration)
-			continue
+	publish := func() {
+		// Don't publish a partial view before every group has loaded once.
+		if !haveStructural || !haveTasks {
+			return
 		}
 
 		data := SwarmData{
@@ -80,8 +174,7 @@ func inspectSwarmServices(cfg *config.Config) {
 		}
 
 		for _, item := range cfg.SensitiveDataPaths {
-			clearErr := internal.ClearByPath(&data, item)
-			if clearErr != nil {
+			if clearErr := internal.ClearByPath(&data, item); clearErr != nil {
 				log.Println("Error clearing sensitive data:", clearErr, item)
 			}
 		}
@@ -90,24 +183,44 @@ func inspectSwarmServices(cfg *config.Config) {
 			jsonBytes, err := json.Marshal(data)
 			if err != nil {
 				log.Println("Error marshalling combined data:", err)
-				time.Sleep(sleepDuration)
-				continue
+				return
 			}
 			lastBroadcastedData.Store(&data)
 			broadcast <- jsonBytes
 		}
+	}
 
-		time.Sleep(sleepDuration)
+	// Initial fetch so clients connecting at startup get a full snapshot
+	// promptly rather than waiting for the first structural tick.
+	refreshStructural()
+	refreshTasks()
+	publish()
+
+	taskTicker := time.NewTicker(taskPollInterval)
+	defer taskTicker.Stop()
+	structuralTicker := time.NewTicker(structuralPollInterval)
+	defer structuralTicker.Stop()
+
+	for {
+		select {
+		case <-taskTicker.C:
+			if refreshTasks() {
+				publish()
+			}
+		case <-structuralTicker.C:
+			if refreshStructural() {
+				publish()
+			}
+		}
 	}
 }
 
-func getNetworksInfo(ctx context.Context, cli *client.Client, cfg *config.Config) ([]network.Summary, error) {
-	result, err := cli.NetworkList(ctx, client.NetworkListOptions{Filters: make(client.Filters).Add("scope", "swarm")})
+func getNetworksInfo(ctx context.Context, src swarmSource, cfg *config.Config) ([]network.Summary, error) {
+	networks, err := src.Networks(ctx)
 	if err != nil {
 		log.Printf("Error fetching networks: %v", err)
 		return nil, err
 	}
-	networks := result.Items
 
 	filteredNetworks := make([]network.Summary, 0, len(networks))
 	for _, net := range networks {
@@ -124,41 +237,34 @@ func getNetworksInfo(ctx context.Context, cli *client.Client, cfg *config.Config
 	return filteredNetworks, nil
 }
 
-func getNodesInfo(ctx context.Context, cli *client.Client, cfg *config.Config) ([]swarm.Node, error) {
-	result, err := cli.NodeList(ctx, client.NodeListOptions{})
+func getNodesInfo(ctx context.Context, src swarmSource, cfg *config.Config) ([]swarm.Node, error) {
+	nodes, err := src.Nodes(ctx)
 	if err != nil {
 		log.Printf("Error fetching nodes: %v", err)
 		return nil, err
 	}
 
-	// Sanitize nodes
-	nodes := sanitizeNodes(result.Items, cfg)
-
-	return nodes, nil
+	return sanitizeNodes(nodes, cfg), nil
 }
 
-func getServicesInfo(ctx context.Context, cli *client.Client, cfg *config.Config) ([]swarm.Service, error) {
-	result, err := cli.ServiceList(ctx, client.ServiceListOptions{})
+func getServicesInfo(ctx context.Context, src swarmSource, cfg *config.Config) ([]swarm.Service, error) {
+	services, err := src.Services(ctx)
 	if err != nil {
 		log.Printf("Error fetching services: %v", err)
 		return nil, err
 	}
 
-	// Sanitize services
-	services := sanitizeServices(result.Items, cfg)
-
-	return services, nil
+	return sanitizeServices(services, cfg), nil
 }
 
 const failedTaskGracePeriod = 30 * time.Second
 
-func getTasksInfo(ctx context.Context, cli *client.Client, cfg *config.Config) ([]swarm.Task, error) {
-	taskList, err := cli.TaskList(ctx, client.TaskListOptions{})
+func getTasksInfo(ctx context.Context, src swarmSource, cfg *config.Config) ([]swarm.Task, error) {
+	tasks, err := src.Tasks(ctx)
 	if err != nil {
 		log.Printf("Error fetching tasks: %v", err)
 		return nil, err
 	}
-	tasks := taskList.Items
 
 	now := time.Now()
 

--- a/internal/docker/source_test.go
+++ b/internal/docker/source_test.go
@@ -1,0 +1,130 @@
+package docker
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/jtgasper3/swarm-visualizer/internal/config"
+	"github.com/moby/moby/api/types/network"
+	"github.com/moby/moby/api/types/swarm"
+)
+
+// fakeSource is a swarmSource backed by canned data for tests.
+type fakeSource struct {
+	nodes    []swarm.Node
+	services []swarm.Service
+	tasks    []swarm.Task
+	networks []network.Summary
+	err      error
+}
+
+func (f fakeSource) Nodes(context.Context) ([]swarm.Node, error)         { return f.nodes, f.err }
+func (f fakeSource) Services(context.Context) ([]swarm.Service, error)   { return f.services, f.err }
+func (f fakeSource) Tasks(context.Context) ([]swarm.Task, error)         { return f.tasks, f.err }
+func (f fakeSource) Networks(context.Context) ([]network.Summary, error) { return f.networks, f.err }
+
+func taskIDs(tasks []swarm.Task) map[string]bool {
+	ids := make(map[string]bool, len(tasks))
+	for _, t := range tasks {
+		ids[t.ID] = true
+	}
+	return ids
+}
+
+func TestGetTasksInfo_FiltersRunningAndRecentlyStopped(t *testing.T) {
+	stoppedTaskCache = make(map[string]cachedTask)
+	t.Cleanup(func() { stoppedTaskCache = make(map[string]cachedTask) })
+
+	now := time.Now()
+	src := fakeSource{tasks: []swarm.Task{
+		// Running task: always included.
+		{ID: "run1", ServiceID: "s1", Slot: 1, DesiredState: swarm.TaskStateRunning,
+			Status: swarm.TaskStatus{State: swarm.TaskStateRunning}},
+		// Recently failed task: included via the stopped-task grace period.
+		{ID: "fail1", ServiceID: "s1", Slot: 2, DesiredState: swarm.TaskStateShutdown,
+			Status: swarm.TaskStatus{State: swarm.TaskStateFailed}, Meta: swarm.Meta{UpdatedAt: now}},
+		// Long-stopped task: excluded as historical.
+		{ID: "old1", ServiceID: "s1", Slot: 3, DesiredState: swarm.TaskStateShutdown,
+			Status: swarm.TaskStatus{State: swarm.TaskStateComplete}, Meta: swarm.Meta{UpdatedAt: now.Add(-time.Hour)}},
+	}}
+
+	out, err := getTasksInfo(context.Background(), src, &config.Config{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	ids := taskIDs(out)
+	if !ids["run1"] {
+		t.Error("expected running task run1 to be included")
+	}
+	if !ids["fail1"] {
+		t.Error("expected recently-failed task fail1 to be included")
+	}
+	if ids["old1"] {
+		t.Error("expected long-stopped task old1 to be excluded")
+	}
+}
+
+func TestGetTasksInfo_NewestStoppedPerSlotWins(t *testing.T) {
+	stoppedTaskCache = make(map[string]cachedTask)
+	t.Cleanup(func() { stoppedTaskCache = make(map[string]cachedTask) })
+
+	now := time.Now()
+	src := fakeSource{tasks: []swarm.Task{
+		// Two failed tasks for the same service+slot; only the newest should show.
+		{ID: "old", ServiceID: "s1", Slot: 1, DesiredState: swarm.TaskStateShutdown,
+			Status: swarm.TaskStatus{State: swarm.TaskStateFailed}, Meta: swarm.Meta{UpdatedAt: now, CreatedAt: now.Add(-2 * time.Minute)}},
+		{ID: "new", ServiceID: "s1", Slot: 1, DesiredState: swarm.TaskStateShutdown,
+			Status: swarm.TaskStatus{State: swarm.TaskStateFailed}, Meta: swarm.Meta{UpdatedAt: now, CreatedAt: now.Add(-1 * time.Minute)}},
+	}}
+
+	out, err := getTasksInfo(context.Background(), src, &config.Config{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	ids := taskIDs(out)
+	if !ids["new"] {
+		t.Error("expected the newest stopped task in the slot to be included")
+	}
+	if ids["old"] {
+		t.Error("expected the older stopped task in the same slot to be excluded")
+	}
+}
+
+func TestGetNetworksInfo_RemovesIngressAndHidesLabels(t *testing.T) {
+	src := fakeSource{networks: []network.Summary{
+		{Network: network.Network{Name: "ingress", Labels: map[string]string{"k": "v"}}},
+		{Network: network.Network{Name: "app", Labels: map[string]string{"k": "v"}}},
+	}}
+
+	// Default config: ingress dropped, labels retained.
+	out, err := getNetworksInfo(context.Background(), src, &config.Config{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(out) != 1 || out[0].Name != "app" {
+		t.Fatalf("expected only the app network, got %#v", out)
+	}
+	if out[0].Labels == nil {
+		t.Error("expected labels to be retained by default")
+	}
+
+	// HideLabels=network: labels stripped.
+	out, err = getNetworksInfo(context.Background(), src, &config.Config{HideLabels: []string{"network"}})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if out[0].Labels != nil {
+		t.Errorf("expected network labels to be hidden, got %#v", out[0].Labels)
+	}
+}
+
+func TestGetInfo_PropagatesError(t *testing.T) {
+	src := fakeSource{err: context.DeadlineExceeded}
+	if _, err := getTasksInfo(context.Background(), src, &config.Config{}); err == nil {
+		t.Error("expected error from getTasksInfo")
+	}
+	if _, err := getNodesInfo(context.Background(), src, &config.Config{}); err == nil {
+		t.Error("expected error from getNodesInfo")
+	}
+}


### PR DESCRIPTION
> **Stacked on `ws-per-client-send` (PR #49).** Review/merge that first; this PR's base should be retargeted to `main` once it lands (GitHub usually does this automatically).

**#9 — replace the 1s full poll.** Docker's events API has no `task` event type and the manager's stream doesn't see worker container lifecycle, so tasks must keep being polled; structural data changes rarely. Rather than a full event-stream rewrite, split the cadence: `TaskList` every 1s (unchanged freshness), `NodeList`/`ServiceList`/`NetworkList` every 5s, caching each group and reassembling on publish. Reassembly still applies `SensitiveDataPaths` via `ClearByPath`, which only zeroes fields and is idempotent, so re-applying it to a cached slice shared with the previous snapshot is safe for change detection. Bonus resilience: never publishes a partial view before all groups load once, and a transient fetch failure keeps the last-good value instead of blanking the view.

**#13 (narrow slice) — testability.** Extract a `swarmSource` interface (`Nodes/Services/Tasks/Networks`) with a `mobySource` adapter over the real client, injected into `inspectSwarmServices`. Adds fake-daemon tests for task filtering, newest-stopped-per-slot, ingress/label network filtering, and error propagation.

Verified end to end against a live swarm: clean polling (no fetch errors) and a full snapshot delivered over `/ws`. `go test -race ./...` green.

The broader #13 (retire globals, dedicated ServeMux, `/ws`+OAuth integration tests) is a follow-up best done after these branches land.

🤖 Generated with [Claude Code](https://claude.com/claude-code)