### PR TITLE
#13 (stage 1): thread a dedicated *http.ServeMux

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -20,26 +20,21 @@ func main() {
 	contextRoot := cfg.ContextRoot
 	log.Printf("Server root context is %s", contextRoot)
 
-	fs := http.FileServer(http.Dir("./static"))
-	http.Handle(contextRoot, http.StripPrefix(contextRoot, fs))
+	mux := http.NewServeMux()
 
-	docker.RegisterDockerHandlers(cfg)
-	oauth.RegisterOAuthHandlers(cfg)
+	fs := http.FileServer(http.Dir("./static"))
+	mux.Handle(contextRoot, http.StripPrefix(contextRoot, fs))
+
+	docker.RegisterDockerHandlers(mux, cfg)
+	oauth.RegisterOAuthHandlers(mux, cfg)
 
 	// Unauthenticated readiness endpoint at a fixed path (independent of
-	// CONTEXT_ROOT) for orchestrator health checks. Reports ready once the
-	// first successful Docker poll has published data.
-	http.HandleFunc("/healthz", func(w http.ResponseWriter, r *http.Request) {
-		if docker.Ready() {
-			w.Header().Set("Content-Type", "text/plain")
-			_, _ = w.Write([]byte("ok"))
-			return
-		}
-		http.Error(w, "not ready", http.StatusServiceUnavailable)
-	})
+	// CONTEXT_ROOT) for orchestrator health checks.
+	mux.Handle("/healthz", healthzHandler(docker.Ready))
 
 	server := &http.Server{
 		Addr:              ":" + cfg.ListenerPort,
+		Handler:           mux,
 		ReadHeaderTimeout: 10 * time.Second,
 		WriteTimeout:      90 * time.Second,
 	}
@@ -62,4 +57,18 @@ func main() {
 		log.Fatal("Server forced to shutdown: ", err)
 	}
 	log.Println("Server stopped")
+}
+
+// healthzHandler reports readiness for orchestrator health checks. It returns
+// 200 once ready returns true (the first successful Docker poll has published
+// data) and 503 otherwise.
+func healthzHandler(ready func() bool) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if ready() {
+			w.Header().Set("Content-Type", "text/plain")
+			_, _ = w.Write([]byte("ok"))
+			return
+		}
+		http.Error(w, "not ready", http.StatusServiceUnavailable)
+	}
 }

--- a/cmd/server/main_test.go
+++ b/cmd/server/main_test.go
@@ -1,0 +1,33 @@
+package main
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestHealthzHandler(t *testing.T) {
+	tests := []struct {
+		name  string
+		ready bool
+		want  int
+	}{
+		{name: "ready returns 200", ready: true, want: http.StatusOK},
+		{name: "not ready returns 503", ready: false, want: http.StatusServiceUnavailable},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			h := healthzHandler(func() bool { return tc.ready })
+			rr := httptest.NewRecorder()
+			h.ServeHTTP(rr, httptest.NewRequest(http.MethodGet, "/healthz", nil))
+
+			if rr.Code != tc.want {
+				t.Fatalf("status = %d, want %d", rr.Code, tc.want)
+			}
+			if tc.ready && rr.Body.String() != "ok" {
+				t.Fatalf("body = %q, want %q", rr.Body.String(), "ok")
+			}
+		})
+	}
+}

--- a/internal/docker/handlers.go
+++ b/internal/docker/handlers.go
@@ -71,7 +71,7 @@ type wsClient struct {
 	send chan []byte
 }
 
-func RegisterDockerHandlers(cfg *config.Config) {
+func RegisterDockerHandlers(mux *http.ServeMux, cfg *config.Config) {
 	maxClients = cfg.MaxWSConnections
 
 	src, err := newMobySource()
@@ -82,10 +82,9 @@ func RegisterDockerHandlers(cfg *config.Config) {
 	go inspectSwarmServices(cfg, src)
 	go handleBroadcasts()
 
-	http.HandleFunc(cfg.ContextRoot+"ws", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc(cfg.ContextRoot+"ws", func(w http.ResponseWriter, r *http.Request) {
 		handleConnections(cfg, w, r)
 	})
-
 }
 
 func handleConnections(cfg *config.Config, w http.ResponseWriter, r *http.Request) {

--- a/internal/oauth/oauth.go
+++ b/internal/oauth/oauth.go
@@ -87,7 +87,7 @@ func cleanupAuthLimiters() {
 	}
 }
 
-func RegisterOAuthHandlers(cfg *config.Config) {
+func RegisterOAuthHandlers(mux *http.ServeMux, cfg *config.Config) {
 	if cfg.AuthEnabled {
 		// Fetch and parse the well-known OIDC config before building the
 		// oauth2.Config so discovered auth/token endpoints are included.
@@ -100,21 +100,21 @@ func RegisterOAuthHandlers(cfg *config.Config) {
 
 		go cleanupAuthLimiters()
 
-		http.HandleFunc(cfg.ContextRoot+"login", func(w http.ResponseWriter, r *http.Request) {
+		mux.HandleFunc(cfg.ContextRoot+"login", func(w http.ResponseWriter, r *http.Request) {
 			if !getAuthLimiter(clientIP(r, cfg.TrustedProxies)).Allow() {
 				http.Error(w, "Too Many Requests", http.StatusTooManyRequests)
 				return
 			}
 			handleLogin(cfg, w, r)
 		})
-		http.HandleFunc(cfg.ContextRoot+"callback", func(w http.ResponseWriter, r *http.Request) {
+		mux.HandleFunc(cfg.ContextRoot+"callback", func(w http.ResponseWriter, r *http.Request) {
 			if !getAuthLimiter(clientIP(r, cfg.TrustedProxies)).Allow() {
 				http.Error(w, "Too Many Requests", http.StatusTooManyRequests)
 				return
 			}
 			handleCallback(cfg, w, r)
 		})
-		http.HandleFunc(cfg.ContextRoot+"logout", func(w http.ResponseWriter, r *http.Request) {
+		mux.HandleFunc(cfg.ContextRoot+"logout", func(w http.ResponseWriter, r *http.Request) {
 			handleLogout(cfg, w, r)
 		})
 	}

--- a/internal/oauth/oauth_test.go
+++ b/internal/oauth/oauth_test.go
@@ -132,13 +132,10 @@ func TestRegisterOAuthHandlersUsesDiscoveredEndpoints(t *testing.T) {
 
 	origOAuthConfig := oauthConfig
 	origSigningKeys := signingKeys
-	origMux := http.DefaultServeMux
 	t.Cleanup(func() {
 		oauthConfig = origOAuthConfig
 		signingKeys = origSigningKeys
-		http.DefaultServeMux = origMux
 	})
-	http.DefaultServeMux = http.NewServeMux()
 
 	cfg := &config.Config{
 		ContextRoot: "/",
@@ -150,7 +147,8 @@ func TestRegisterOAuthHandlersUsesDiscoveredEndpoints(t *testing.T) {
 		},
 	}
 
-	RegisterOAuthHandlers(cfg)
+	mux := http.NewServeMux()
+	RegisterOAuthHandlers(mux, cfg)
 
 	if oauthConfig.Endpoint.AuthURL != "https://issuer.example.com/auth" {
 		t.Fatalf("AuthURL = %q, want discovered endpoint", oauthConfig.Endpoint.AuthURL)
@@ -162,7 +160,7 @@ func TestRegisterOAuthHandlersUsesDiscoveredEndpoints(t *testing.T) {
 	req := httptest.NewRequest(http.MethodGet, "/login", nil)
 	req.RemoteAddr = "192.0.2.1:1234"
 	rr := httptest.NewRecorder()
-	http.DefaultServeMux.ServeHTTP(rr, req)
+	mux.ServeHTTP(rr, req)
 	loc := rr.Header().Get("Location")
 	if !strings.HasPrefix(loc, "https://issuer.example.com/auth?") {
 		t.Fatalf("login redirect Location = %q, want discovered authorization endpoint", loc)


### PR DESCRIPTION
First slice of the #13 structural cleanup (retire package globals / improve testability), kept small and self-contained.

**What changed**
- `main` now creates an explicit `*http.ServeMux` and passes it to `RegisterDockerHandlers(mux, cfg)` and `RegisterOAuthHandlers(mux, cfg)`; `http.Server.Handler = mux`. No more `http.DefaultServeMux` anywhere.
- Extracted the `/healthz` closure in `main` into a testable `healthzHandler(ready func() bool)`.
- Updated the OAuth discovery test to register on a local mux instead of swapping `http.DefaultServeMux` (removing global mutation from the test).
- Added a `cmd/server` test (the package had none).

**Why**
Removes a class of shared global state and lets tests register handlers on an isolated mux, which is the prerequisite for the `/ws` + OAuth integration tests in a later slice.

**Not in this PR (follow-ups)**
- Stage 2: retire the remaining mutable package globals into structs (oauth `Authenticator`, docker `Hub`) — pragmatic split, leaving genuinely-singleton/already-safe state (e.g. `upgrader`, atomic keepalive timings) as-is.
- Stage 3: `/ws` + OAuth integration tests against the mux.

`go build` / `go vet` / `go test -race ./...` all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)