### PR TITLE
#13 (stage 2): move WebSocket fan-out state into a Hub

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -25,12 +25,12 @@ func main() {
 	fs := http.FileServer(http.Dir("./static"))
 	mux.Handle(contextRoot, http.StripPrefix(contextRoot, fs))
 
-	docker.RegisterDockerHandlers(mux, cfg)
+	hub := docker.RegisterDockerHandlers(mux, cfg)
 	oauth.RegisterOAuthHandlers(mux, cfg)
 
 	// Unauthenticated readiness endpoint at a fixed path (independent of
 	// CONTEXT_ROOT) for orchestrator health checks.
-	mux.Handle("/healthz", healthzHandler(docker.Ready))
+	mux.Handle("/healthz", healthzHandler(hub.Ready))
 
 	server := &http.Server{
 		Addr:              ":" + cfg.ListenerPort,

--- a/internal/docker/handlers.go
+++ b/internal/docker/handlers.go
@@ -14,34 +14,66 @@ import (
 	"github.com/jtgasper3/swarm-visualizer/internal/oauth"
 )
 
-var (
-	upgrader = websocket.Upgrader{
-		CheckOrigin: func(r *http.Request) bool {
-			origin := r.Header.Get("Origin")
-			if origin == "" {
-				return true // non-browser clients (curl, native apps)
-			}
-			u, err := url.Parse(origin)
-			if err != nil {
-				return false
-			}
-			return u.Host == r.Host
-		},
-	}
-	clientsMu sync.Mutex
-	clients   = make(map[*wsClient]struct{})
-	// lastFanned is the most recent frame handed to handleBroadcasts, guarded by
-	// clientsMu. A newly registered client is seeded with it (under the same
-	// lock) so its seed is never newer than a frame still queued for fan-out,
-	// which would otherwise make the client briefly roll back to older state.
-	lastFanned []byte
-	// maxClients caps the number of concurrent WebSocket connections to bound
-	// resource use. 0 means unlimited; it is set from config in
-	// RegisterDockerHandlers.
-	maxClients int
-)
+var upgrader = websocket.Upgrader{
+	CheckOrigin: func(r *http.Request) bool {
+		origin := r.Header.Get("Origin")
+		if origin == "" {
+			return true // non-browser clients (curl, native apps)
+		}
+		u, err := url.Parse(origin)
+		if err != nil {
+			return false
+		}
+		return u.Host == r.Host
+	},
+}
 
 const wsWriteTimeout = 5 * time.Second
+
+// Hub owns the set of connected WebSocket clients and fans out snapshot frames
+// to them. One Hub backs the running server; tests construct their own.
+type Hub struct {
+	cfg *config.Config
+
+	mu sync.Mutex
+	// clients is the set of connected clients.
+	clients map[*wsClient]struct{}
+	// lastFanned is the most recent frame handed out, guarded by mu. A newly
+	// registered client is seeded with it (under the same lock) so its seed is
+	// never newer than a frame still queued for fan-out, which would otherwise
+	// make the client briefly roll back to older state.
+	lastFanned []byte
+	// maxClients caps concurrent connections to bound resource use. 0 means
+	// unlimited.
+	maxClients int
+
+	// broadcast carries marshalled snapshots from the inspector to runBroadcasts.
+	broadcast chan []byte
+}
+
+// newHub creates a Hub configured from cfg.
+func newHub(cfg *config.Config) *Hub {
+	return &Hub{
+		cfg:        cfg,
+		clients:    make(map[*wsClient]struct{}),
+		maxClients: cfg.MaxWSConnections,
+		broadcast:  make(chan []byte, 1),
+	}
+}
+
+// Ready reports whether at least one snapshot has been fanned out, i.e. the
+// Docker API is reachable and data has been published. It stays true once the
+// first frame is sent, so it does not flap on transient errors.
+func (h *Hub) Ready() bool {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	return h.lastFanned != nil
+}
+
+// Publish hands a marshalled snapshot to the fan-out goroutine.
+func (h *Hub) Publish(frame []byte) {
+	h.broadcast <- frame
+}
 
 // Keepalive timings: a ping is sent every pingPeriod(), and the read side must
 // see a pong (or any frame) within pongWait() or the peer is considered dead
@@ -71,28 +103,30 @@ type wsClient struct {
 	send chan []byte
 }
 
-func RegisterDockerHandlers(mux *http.ServeMux, cfg *config.Config) {
-	maxClients = cfg.MaxWSConnections
+func RegisterDockerHandlers(mux *http.ServeMux, cfg *config.Config) *Hub {
+	hub := newHub(cfg)
 
 	src, err := newMobySource()
 	if err != nil {
 		log.Fatal("Docker client error:", err)
 	}
 
-	go inspectSwarmServices(cfg, src)
-	go handleBroadcasts()
+	go inspectSwarmServices(cfg, src, hub)
+	go hub.runBroadcasts()
 
-	mux.HandleFunc(cfg.ContextRoot+"ws", func(w http.ResponseWriter, r *http.Request) {
-		handleConnections(cfg, w, r)
-	})
+	mux.HandleFunc(cfg.ContextRoot+"ws", hub.handleConnections)
+
+	return hub
 }
 
-func handleConnections(cfg *config.Config, w http.ResponseWriter, r *http.Request) {
+func (h *Hub) handleConnections(w http.ResponseWriter, r *http.Request) {
+	cfg := h.cfg
+
 	// Shed load before the WebSocket handshake when already at capacity. This
-	// is best effort; registerClient performs the authoritative check.
-	if atClientCapacity() {
+	// is best effort; register performs the authoritative check.
+	if h.atCapacity() {
 		http.Error(w, "Too many connections", http.StatusServiceUnavailable)
-		log.Printf("Connection rejected, server at capacity (%d): %s", maxClients, r.RemoteAddr)
+		log.Printf("Connection rejected, server at capacity (%d): %s", h.maxClients, r.RemoteAddr)
 		return
 	}
 
@@ -119,9 +153,9 @@ func handleConnections(cfg *config.Config, w http.ResponseWriter, r *http.Reques
 
 	c := &wsClient{conn: ws, send: make(chan []byte, 1)}
 
-	if !registerClient(c) {
+	if !h.register(c) {
 		// Capacity was reached between the pre-upgrade check and here.
-		log.Printf("Connection rejected, server at capacity (%d): %s", maxClients, r.RemoteAddr)
+		log.Printf("Connection rejected, server at capacity (%d): %s", h.maxClients, r.RemoteAddr)
 		ws.Close()
 		return
 	}
@@ -147,7 +181,7 @@ func handleConnections(cfg *config.Config, w http.ResponseWriter, r *http.Reques
 			break
 		}
 	}
-	unregisterClient(c)
+	h.unregister(c)
 }
 
 // writePump owns every write to the connection: snapshot frames from send and
@@ -183,27 +217,27 @@ func (c *wsClient) writePump() {
 	}
 }
 
-// atClientCapacity reports whether the concurrent connection limit is reached.
-func atClientCapacity() bool {
-	if maxClients <= 0 {
+// atCapacity reports whether the concurrent connection limit is reached.
+func (h *Hub) atCapacity() bool {
+	if h.maxClients <= 0 {
 		return false
 	}
-	clientsMu.Lock()
-	defer clientsMu.Unlock()
-	return len(clients) >= maxClients
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	return len(h.clients) >= h.maxClients
 }
 
-// registerClient adds the client to the registry and seeds it with the latest
+// register adds the client to the registry and seeds it with the latest
 // snapshot, all under the broadcast lock. It returns false (registering
 // nothing) if the concurrent connection cap is reached.
-func registerClient(c *wsClient) bool {
-	clientsMu.Lock()
-	defer clientsMu.Unlock()
+func (h *Hub) register(c *wsClient) bool {
+	h.mu.Lock()
+	defer h.mu.Unlock()
 
-	if maxClients > 0 && len(clients) >= maxClients {
+	if h.maxClients > 0 && len(h.clients) >= h.maxClients {
 		return false
 	}
-	clients[c] = struct{}{}
+	h.clients[c] = struct{}{}
 
 	// Seed the most recently fanned-out frame, if any, under the same lock that
 	// guards broadcasts. This keeps registration and seeding atomic with respect
@@ -211,34 +245,35 @@ func registerClient(c *wsClient) bool {
 	// "null" frame before the first poll, and is never seeded with a frame newer
 	// than one still queued for fan-out (which would cause a visible rollback).
 	// The send buffer was just created with cap 1, so this never blocks.
-	if lastFanned != nil {
-		c.send <- lastFanned
+	if h.lastFanned != nil {
+		c.send <- h.lastFanned
 	}
 	return true
 }
 
-func unregisterClient(c *wsClient) {
-	clientsMu.Lock()
-	if _, ok := clients[c]; ok {
-		delete(clients, c)
+func (h *Hub) unregister(c *wsClient) {
+	h.mu.Lock()
+	if _, ok := h.clients[c]; ok {
+		delete(h.clients, c)
 		// Closing send terminates writePump's range. Safe against the
 		// broadcaster because it only enqueues to clients still in the map
 		// and holds the same lock.
 		close(c.send)
 	}
-	clientsMu.Unlock()
+	h.mu.Unlock()
 }
 
-func handleBroadcasts() {
-	for msg := range broadcast {
-		clientsMu.Lock()
+// runBroadcasts fans out each published frame to all connected clients.
+func (h *Hub) runBroadcasts() {
+	for msg := range h.broadcast {
+		h.mu.Lock()
 		// Record the frame being fanned out so a client registering concurrently
 		// is seeded with this frame (or a newer one), never a stale one.
-		lastFanned = msg
-		for c := range clients {
+		h.lastFanned = msg
+		for c := range h.clients {
 			enqueue(c, msg)
 		}
-		clientsMu.Unlock()
+		h.mu.Unlock()
 	}
 }
 

--- a/internal/docker/handlers_test.go
+++ b/internal/docker/handlers_test.go
@@ -3,46 +3,34 @@ package docker
 import (
 	"testing"
 	"time"
-)
 
-// resetClientState clears the package-level client registry and seed snapshot
-// so a test starts from a known state.
-func resetClientState(t *testing.T) {
-	t.Helper()
-	t.Cleanup(func() {
-		clientsMu.Lock()
-		clients = make(map[*wsClient]struct{})
-		lastFanned = nil
-		clientsMu.Unlock()
-		maxClients = 0
-	})
-}
+	"github.com/jtgasper3/swarm-visualizer/internal/config"
+)
 
 // TestRegisterClient_EnforcesCap verifies the concurrent connection cap.
 func TestRegisterClient_EnforcesCap(t *testing.T) {
-	resetClientState(t)
-	maxClients = 2
+	h := newHub(&config.Config{MaxWSConnections: 2})
 
 	c1 := &wsClient{send: make(chan []byte, 1)}
 	c2 := &wsClient{send: make(chan []byte, 1)}
 	c3 := &wsClient{send: make(chan []byte, 1)}
 
-	if !registerClient(c1) || !registerClient(c2) {
+	if !h.register(c1) || !h.register(c2) {
 		t.Fatal("expected the first two clients to register")
 	}
-	if registerClient(c3) {
+	if h.register(c3) {
 		t.Fatal("expected the third client to be rejected at capacity")
 	}
-	if atClientCapacity() != true {
-		t.Fatal("expected atClientCapacity to report full")
+	if !h.atCapacity() {
+		t.Fatal("expected atCapacity to report full")
 	}
 
 	// Freeing a slot allows a new client in.
-	unregisterClient(c1)
-	if atClientCapacity() {
+	h.unregister(c1)
+	if h.atCapacity() {
 		t.Fatal("expected capacity after unregister")
 	}
-	if !registerClient(c3) {
+	if !h.register(c3) {
 		t.Fatal("expected registration to succeed after a slot freed")
 	}
 }
@@ -50,13 +38,13 @@ func TestRegisterClient_EnforcesCap(t *testing.T) {
 // TestRegisterClient_SeedsLatestSnapshot verifies a newly registered client is
 // seeded with the most recent snapshot.
 func TestRegisterClient_SeedsLatestSnapshot(t *testing.T) {
-	resetClientState(t)
+	h := newHub(&config.Config{})
 
 	payload := []byte(`{"clusterName":"test"}`)
-	lastFanned = payload
+	h.lastFanned = payload
 
 	c := &wsClient{send: make(chan []byte, 1)}
-	registerClient(c)
+	h.register(c)
 
 	select {
 	case got := <-c.send:
@@ -71,11 +59,10 @@ func TestRegisterClient_SeedsLatestSnapshot(t *testing.T) {
 // TestRegisterClient_NoSeedBeforeFirstSnapshot verifies that a client that
 // connects before any data has been produced is not sent a "null" frame.
 func TestRegisterClient_NoSeedBeforeFirstSnapshot(t *testing.T) {
-	resetClientState(t)
-	lastFanned = nil
+	h := newHub(&config.Config{})
 
 	c := &wsClient{send: make(chan []byte, 1)}
-	registerClient(c)
+	h.register(c)
 
 	select {
 	case got := <-c.send:

--- a/internal/docker/inspect.go
+++ b/internal/docker/inspect.go
@@ -8,7 +8,6 @@ import (
 	"reflect"
 	"slices"
 	"strings"
-	"sync/atomic"
 	"time"
 
 	"github.com/jtgasper3/swarm-visualizer/internal"
@@ -33,21 +32,8 @@ type cachedTask struct {
 	firstSeen time.Time
 }
 
-var (
-	broadcast = make(chan []byte, 1)
-	// lastBroadcastedData holds the most recent snapshot for change detection;
-	// it is written and read only by the single inspectSwarmServices goroutine.
-	lastBroadcastedData atomic.Pointer[SwarmData]
-	// stoppedTaskCache is only accessed from the single inspectSwarmServices goroutine.
-	stoppedTaskCache = make(map[string]cachedTask)
-)
-
-// Ready reports whether at least one successful swarm inspection has completed,
-// i.e. the Docker API is reachable and data has been published. It stays true
-// once the first poll succeeds, so it does not flap on transient errors.
-func Ready() bool {
-	return lastBroadcastedData.Load() != nil
-}
+// stoppedTaskCache is only accessed from the single inspectSwarmServices goroutine.
+var stoppedTaskCache = make(map[string]cachedTask)
 
 // swarmSource is the subset of the Docker API the inspector needs. It is an
 // interface so tests can substitute a fake daemon for the real client.
@@ -123,7 +109,7 @@ const (
 // fields and is therefore idempotent; re-applying it to a cached (already
 // cleared) slice that is also referenced by the previously published snapshot
 // leaves that snapshot's bytes unchanged, so change detection stays correct.
-func inspectSwarmServices(cfg *config.Config, src swarmSource) {
+func inspectSwarmServices(cfg *config.Config, src swarmSource, hub *Hub) {
 	ctx := context.Background()
 
 	var (
@@ -134,6 +120,10 @@ func inspectSwarmServices(cfg *config.Config, src swarmSource) {
 
 		haveStructural bool
 		haveTasks      bool
+
+		// lastPublished is the previous snapshot, kept for change detection. It is
+		// only touched by this single goroutine.
+		lastPublished *SwarmData
 	)
 
 	refreshStructural := func() bool {
@@ -179,14 +169,14 @@ func inspectSwarmServices(cfg *config.Config, src swarmSource) {
 			}
 		}
 
-		if prev := lastBroadcastedData.Load(); prev == nil || !reflect.DeepEqual(data, *prev) {
+		if lastPublished == nil || !reflect.DeepEqual(data, *lastPublished) {
 			jsonBytes, err := json.Marshal(data)
 			if err != nil {
 				log.Println("Error marshalling combined data:", err)
 				return
 			}
-			lastBroadcastedData.Store(&data)
-			broadcast <- jsonBytes
+			lastPublished = &data
+			hub.Publish(jsonBytes)
 		}
 	}
 

--- a/internal/docker/inspect_test.go
+++ b/internal/docker/inspect_test.go
@@ -9,17 +9,15 @@ import (
 )
 
 func TestReady(t *testing.T) {
-	orig := lastBroadcastedData.Load()
-	t.Cleanup(func() { lastBroadcastedData.Store(orig) })
+	h := newHub(&config.Config{})
 
-	lastBroadcastedData.Store(nil)
-	if Ready() {
-		t.Fatal("expected not ready before the first successful poll")
+	if h.Ready() {
+		t.Fatal("expected not ready before the first frame is fanned out")
 	}
 
-	lastBroadcastedData.Store(&SwarmData{})
-	if !Ready() {
-		t.Fatal("expected ready once data has been published")
+	h.lastFanned = []byte(`{}`)
+	if !h.Ready() {
+		t.Fatal("expected ready once a frame has been fanned out")
 	}
 }
 

--- a/internal/docker/keepalive_test.go
+++ b/internal/docker/keepalive_test.go
@@ -12,10 +12,10 @@ import (
 	"github.com/jtgasper3/swarm-visualizer/internal/config"
 )
 
-func clientCount() int {
-	clientsMu.Lock()
-	defer clientsMu.Unlock()
-	return len(clients)
+func clientCount(h *Hub) int {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	return len(h.clients)
 }
 
 // setKeepalive overrides the ping/pong timings for the duration of a test.
@@ -47,13 +47,10 @@ func waitFor(t *testing.T, cond func() bool, timeout time.Duration) bool {
 // that does not read also never auto-replies to pings, which simulates a peer
 // that has silently vanished.
 func TestKeepalive_ReapsUnresponsivePeer(t *testing.T) {
-	resetClientState(t)
 	setKeepalive(t, 50*time.Millisecond, 250*time.Millisecond)
 
-	cfg := &config.Config{ContextRoot: "/"}
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		handleConnections(cfg, w, r)
-	}))
+	h := newHub(&config.Config{ContextRoot: "/"})
+	srv := httptest.NewServer(http.HandlerFunc(h.handleConnections))
 	defer srv.Close()
 
 	wsURL := "ws" + strings.TrimPrefix(srv.URL, "http") + "/ws"
@@ -65,26 +62,23 @@ func TestKeepalive_ReapsUnresponsivePeer(t *testing.T) {
 	// Deliberately never read from conn: the client never auto-replies to the
 	// server's pings, so the server should reap it after pongWait.
 
-	if !waitFor(t, func() bool { return clientCount() == 1 }, 2*time.Second) {
-		t.Fatalf("client never registered (count=%d)", clientCount())
+	if !waitFor(t, func() bool { return clientCount(h) == 1 }, 2*time.Second) {
+		t.Fatalf("client never registered (count=%d)", clientCount(h))
 	}
-	if !waitFor(t, func() bool { return clientCount() == 0 }, 3*time.Second) {
-		t.Fatalf("unresponsive client was not reaped (count=%d)", clientCount())
+	if !waitFor(t, func() bool { return clientCount(h) == 0 }, 3*time.Second) {
+		t.Fatalf("unresponsive client was not reaped (count=%d)", clientCount(h))
 	}
 }
 
 // TestKeepalive_ResponsivePeerStaysConnected verifies that a client which reads
 // (and therefore auto-replies to pings) is not reaped.
 func TestKeepalive_ResponsivePeerStaysConnected(t *testing.T) {
-	resetClientState(t)
 	// Keep pongWait generously larger than pingPeriod so frequent pongs hold the
 	// deadline open even under the scheduling jitter of the race detector.
 	setKeepalive(t, 50*time.Millisecond, 600*time.Millisecond)
 
-	cfg := &config.Config{ContextRoot: "/"}
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		handleConnections(cfg, w, r)
-	}))
+	h := newHub(&config.Config{ContextRoot: "/"})
+	srv := httptest.NewServer(http.HandlerFunc(h.handleConnections))
 	defer srv.Close()
 
 	wsURL := "ws" + strings.TrimPrefix(srv.URL, "http") + "/ws"
@@ -105,13 +99,13 @@ func TestKeepalive_ResponsivePeerStaysConnected(t *testing.T) {
 		}
 	}()
 
-	if !waitFor(t, func() bool { return clientCount() == 1 }, 2*time.Second) {
-		t.Fatalf("client never registered (count=%d)", clientCount())
+	if !waitFor(t, func() bool { return clientCount(h) == 1 }, 2*time.Second) {
+		t.Fatalf("client never registered (count=%d)", clientCount(h))
 	}
 	// Past a full pongWait window (many ping/pong cycles), a responsive client
 	// must still be connected.
 	time.Sleep(pongWait() + 200*time.Millisecond)
-	if got := clientCount(); got != 1 {
+	if got := clientCount(h); got != 1 {
 		t.Fatalf("responsive client should stay connected, count=%d", got)
 	}
 


### PR DESCRIPTION
> **Stacked on #51** (stage 1). Review/merge that first; this PR's base will retarget to `main` once it lands.

Second slice of #13. Retires the package-level WebSocket globals into a `Hub`.

**What changed**
- `clients`, `clientsMu`, `lastFanned`, `maxClients`, the `broadcast` channel, and `lastBroadcastedData` are now fields of a `Hub` struct. `handleConnections`, `register`/`unregister`, `atCapacity`, and `runBroadcasts` are Hub methods; `RegisterDockerHandlers` constructs one and returns it.
- Readiness moved onto the Hub (`Hub.Ready` = "a frame has been fanned out"), so `main` wires `/healthz` to `hub.Ready`; the package-level `Ready`/`lastBroadcastedData` are gone.
- The inspector keeps its change-detection snapshot in a local and publishes via `hub.Publish`, so two Hubs never share a broadcast channel — tests now construct an **isolated Hub per test** instead of resetting globals (removed `resetClientState`).

**Left package-level per the pragmatic (b) scope**
The `upgrader` (stateless), the atomic keepalive timings, and the single-goroutine `stoppedTaskCache` — genuinely singleton / already-safe.

`go test -race ./...` green (incl. keepalive ×3). Verified end to end against a live swarm: `/healthz` returns 503 before the first poll and 200 after, and a snapshot is delivered over `/ws`.

**Next slices:** oauth `Authenticator` struct (retire `oauthConfig`/`signingKeys`/limiter globals), then `/ws` + OAuth integration tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)