### PR TITLE
#13 (stage 3): retire oauth globals into an Authenticator

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -25,8 +25,15 @@ func main() {
 	fs := http.FileServer(http.Dir("./static"))
 	mux.Handle(contextRoot, http.StripPrefix(contextRoot, fs))
 
-	hub := docker.RegisterDockerHandlers(mux, cfg)
-	oauth.RegisterOAuthHandlers(mux, cfg)
+	// Register auth first so its token validator can be handed to the WebSocket
+	// handler. auth is nil when authentication is disabled.
+	auth := oauth.RegisterOAuthHandlers(mux, cfg)
+	var validate docker.TokenValidator
+	if auth != nil {
+		validate = auth.ValidateToken
+	}
+
+	hub := docker.RegisterDockerHandlers(mux, cfg, validate)
 
 	// Unauthenticated readiness endpoint at a fixed path (independent of
 	// CONTEXT_ROOT) for orchestrator health checks.

--- a/internal/docker/handlers.go
+++ b/internal/docker/handlers.go
@@ -8,11 +8,16 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/golang-jwt/jwt/v5"
 	"github.com/gorilla/websocket"
 
 	"github.com/jtgasper3/swarm-visualizer/internal/config"
-	"github.com/jtgasper3/swarm-visualizer/internal/oauth"
 )
+
+// TokenValidator validates the ID token on an incoming request and returns its
+// claims. It decouples the WebSocket handler from the oauth package; the running
+// server wires in oauth.Authenticator.ValidateToken.
+type TokenValidator func(*http.Request) (jwt.MapClaims, error)
 
 var upgrader = websocket.Upgrader{
 	CheckOrigin: func(r *http.Request) bool {
@@ -34,6 +39,9 @@ const wsWriteTimeout = 5 * time.Second
 // to them. One Hub backs the running server; tests construct their own.
 type Hub struct {
 	cfg *config.Config
+	// validate authenticates a connection when cfg.AuthEnabled. It is nil when
+	// auth is disabled.
+	validate TokenValidator
 
 	mu sync.Mutex
 	// clients is the set of connected clients.
@@ -51,10 +59,12 @@ type Hub struct {
 	broadcast chan []byte
 }
 
-// newHub creates a Hub configured from cfg.
-func newHub(cfg *config.Config) *Hub {
+// newHub creates a Hub configured from cfg. validate may be nil when auth is
+// disabled.
+func newHub(cfg *config.Config, validate TokenValidator) *Hub {
 	return &Hub{
 		cfg:        cfg,
+		validate:   validate,
 		clients:    make(map[*wsClient]struct{}),
 		maxClients: cfg.MaxWSConnections,
 		broadcast:  make(chan []byte, 1),
@@ -103,8 +113,8 @@ type wsClient struct {
 	send chan []byte
 }
 
-func RegisterDockerHandlers(mux *http.ServeMux, cfg *config.Config) *Hub {
-	hub := newHub(cfg)
+func RegisterDockerHandlers(mux *http.ServeMux, cfg *config.Config, validate TokenValidator) *Hub {
+	hub := newHub(cfg, validate)
 
 	src, err := newMobySource()
 	if err != nil {
@@ -138,7 +148,7 @@ func (h *Hub) handleConnections(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if cfg.AuthEnabled {
-		claims, err := oauth.ValidateToken(cfg, r)
+		claims, err := h.validate(r)
 		if err != nil {
 			ws.SetWriteDeadline(time.Now().Add(wsWriteTimeout))
 			ws.WriteMessage(websocket.TextMessage, []byte("401-Unauthorized"))

--- a/internal/docker/handlers_test.go
+++ b/internal/docker/handlers_test.go
@@ -9,7 +9,7 @@ import (
 
 // TestRegisterClient_EnforcesCap verifies the concurrent connection cap.
 func TestRegisterClient_EnforcesCap(t *testing.T) {
-	h := newHub(&config.Config{MaxWSConnections: 2})
+	h := newHub(&config.Config{MaxWSConnections: 2}, nil)
 
 	c1 := &wsClient{send: make(chan []byte, 1)}
 	c2 := &wsClient{send: make(chan []byte, 1)}
@@ -38,7 +38,7 @@ func TestRegisterClient_EnforcesCap(t *testing.T) {
 // TestRegisterClient_SeedsLatestSnapshot verifies a newly registered client is
 // seeded with the most recent snapshot.
 func TestRegisterClient_SeedsLatestSnapshot(t *testing.T) {
-	h := newHub(&config.Config{})
+	h := newHub(&config.Config{}, nil)
 
 	payload := []byte(`{"clusterName":"test"}`)
 	h.lastFanned = payload
@@ -59,7 +59,7 @@ func TestRegisterClient_SeedsLatestSnapshot(t *testing.T) {
 // TestRegisterClient_NoSeedBeforeFirstSnapshot verifies that a client that
 // connects before any data has been produced is not sent a "null" frame.
 func TestRegisterClient_NoSeedBeforeFirstSnapshot(t *testing.T) {
-	h := newHub(&config.Config{})
+	h := newHub(&config.Config{}, nil)
 
 	c := &wsClient{send: make(chan []byte, 1)}
 	h.register(c)

--- a/internal/docker/inspect_test.go
+++ b/internal/docker/inspect_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 func TestReady(t *testing.T) {
-	h := newHub(&config.Config{})
+	h := newHub(&config.Config{}, nil)
 
 	if h.Ready() {
 		t.Fatal("expected not ready before the first frame is fanned out")

--- a/internal/docker/keepalive_test.go
+++ b/internal/docker/keepalive_test.go
@@ -49,7 +49,7 @@ func waitFor(t *testing.T, cond func() bool, timeout time.Duration) bool {
 func TestKeepalive_ReapsUnresponsivePeer(t *testing.T) {
 	setKeepalive(t, 50*time.Millisecond, 250*time.Millisecond)
 
-	h := newHub(&config.Config{ContextRoot: "/"})
+	h := newHub(&config.Config{ContextRoot: "/"}, nil)
 	srv := httptest.NewServer(http.HandlerFunc(h.handleConnections))
 	defer srv.Close()
 
@@ -77,7 +77,7 @@ func TestKeepalive_ResponsivePeerStaysConnected(t *testing.T) {
 	// deadline open even under the scheduling jitter of the race detector.
 	setKeepalive(t, 50*time.Millisecond, 600*time.Millisecond)
 
-	h := newHub(&config.Config{ContextRoot: "/"})
+	h := newHub(&config.Config{ContextRoot: "/"}, nil)
 	srv := httptest.NewServer(http.HandlerFunc(h.handleConnections))
 	defer srv.Close()
 

--- a/internal/oauth/callback_test.go
+++ b/internal/oauth/callback_test.go
@@ -15,19 +15,19 @@ import (
 )
 
 func TestHandleLogin_SetsStateAndNonce(t *testing.T) {
-	orig := oauthConfig
-	t.Cleanup(func() { oauthConfig = orig })
-	oauthConfig = &oauth2.Config{
-		ClientID:    "client-1",
-		RedirectURL: "https://app.example.com/callback",
-		Endpoint:    oauth2.Endpoint{AuthURL: "https://issuer.example.com/auth"},
+	a := &Authenticator{
+		cfg: &config.Config{ContextRoot: "/"},
+		oauthConfig: &oauth2.Config{
+			ClientID:    "client-1",
+			RedirectURL: "https://app.example.com/callback",
+			Endpoint:    oauth2.Endpoint{AuthURL: "https://issuer.example.com/auth"},
+		},
 	}
 
-	cfg := &config.Config{ContextRoot: "/"}
 	req := httptest.NewRequest(http.MethodGet, "/login", nil)
 	rr := httptest.NewRecorder()
 
-	handleLogin(cfg, rr, req)
+	a.handleLogin(rr, req)
 
 	if rr.Code != http.StatusTemporaryRedirect {
 		t.Fatalf("status = %d, want %d", rr.Code, http.StatusTemporaryRedirect)
@@ -61,9 +61,7 @@ func TestHandleCallback_NonceValidation(t *testing.T) {
 	}
 	const kid, issuer, client = "kid1", "https://issuer.example.com", "client-1"
 
-	origKeys, origCfg := signingKeys, oauthConfig
-	t.Cleanup(func() { signingKeys = origKeys; oauthConfig = origCfg })
-	signingKeys = &keyStore{
+	keys := &keyStore{
 		keys:        map[string]*rsa.PublicKey{kid: &key.PublicKey},
 		lastRefresh: time.Now(),
 	}
@@ -95,16 +93,20 @@ func TestHandleCallback_NonceValidation(t *testing.T) {
 		}))
 		defer tokenSrv.Close()
 
-		oauthConfig = &oauth2.Config{
-			ClientID: client,
-			Endpoint: oauth2.Endpoint{TokenURL: tokenSrv.URL, AuthURL: "https://issuer.example.com/auth"},
+		a := &Authenticator{
+			cfg:  cfg,
+			keys: keys,
+			oauthConfig: &oauth2.Config{
+				ClientID: client,
+				Endpoint: oauth2.Endpoint{TokenURL: tokenSrv.URL, AuthURL: "https://issuer.example.com/auth"},
+			},
 		}
 
 		req := httptest.NewRequest(http.MethodGet, "/callback?code=abc&state=xyz", nil)
 		req.AddCookie(&http.Cookie{Name: "state", Value: "xyz"})
 		req.AddCookie(&http.Cookie{Name: "nonce", Value: cookieNonce})
 		rr := httptest.NewRecorder()
-		handleCallback(cfg, rr, req)
+		a.handleCallback(rr, req)
 		return rr
 	}
 
@@ -139,11 +141,11 @@ func TestHandleCallback_NonceValidation(t *testing.T) {
 }
 
 func TestHandleLogout_ClearsSession(t *testing.T) {
-	cfg := &config.Config{ContextRoot: "/"}
+	a := &Authenticator{cfg: &config.Config{ContextRoot: "/"}}
 	req := httptest.NewRequest(http.MethodGet, "/logout", nil)
 	rr := httptest.NewRecorder()
 
-	handleLogout(cfg, rr, req)
+	a.handleLogout(rr, req)
 
 	if rr.Code != http.StatusTemporaryRedirect {
 		t.Fatalf("status = %d, want %d", rr.Code, http.StatusTemporaryRedirect)

--- a/internal/oauth/idtoken.go
+++ b/internal/oauth/idtoken.go
@@ -6,10 +6,11 @@ import (
 	"strings"
 
 	"github.com/golang-jwt/jwt/v5"
-	"github.com/jtgasper3/swarm-visualizer/internal/config"
 )
 
-func ValidateToken(cfg *config.Config, r *http.Request) (jwt.MapClaims, error) {
+// ValidateToken extracts the ID token from the request (cookie or bearer
+// header) and verifies it.
+func (a *Authenticator) ValidateToken(r *http.Request) (jwt.MapClaims, error) {
 	var rawIDToken string
 	cookie, err := r.Cookie("id_token")
 	if err != nil {
@@ -23,13 +24,13 @@ func ValidateToken(cfg *config.Config, r *http.Request) (jwt.MapClaims, error) {
 		rawIDToken = cookie.Value
 	}
 
-	return validateRawToken(cfg, rawIDToken)
+	return a.validateRawToken(rawIDToken)
 }
 
 // validateRawToken verifies an ID token's signature, issuer, and audience and
 // returns its claims. It is shared by the WebSocket request path and the OAuth
 // callback (which additionally checks the nonce).
-func validateRawToken(cfg *config.Config, rawIDToken string) (jwt.MapClaims, error) {
+func (a *Authenticator) validateRawToken(rawIDToken string) (jwt.MapClaims, error) {
 	token, err := jwt.Parse(rawIDToken, func(token *jwt.Token) (interface{}, error) {
 		if _, ok := token.Method.(*jwt.SigningMethodRSA); !ok {
 			return nil, fmt.Errorf("unexpected signing method: %v", token.Header["alg"])
@@ -40,10 +41,10 @@ func validateRawToken(cfg *config.Config, rawIDToken string) (jwt.MapClaims, err
 			return nil, fmt.Errorf("missing kid in token header")
 		}
 
-		if signingKeys == nil {
+		if a.keys == nil {
 			return nil, fmt.Errorf("signing keys not initialized")
 		}
-		rsaPublicKey, ok := signingKeys.key(kid)
+		rsaPublicKey, ok := a.keys.key(kid)
 		if !ok {
 			return nil, fmt.Errorf("unknown kid: %s", kid)
 		}
@@ -59,12 +60,12 @@ func validateRawToken(cfg *config.Config, rawIDToken string) (jwt.MapClaims, err
 		return nil, fmt.Errorf("unauthorized")
 	}
 
-	if cfg.OAuthConfig.Issuer != "" {
+	if a.cfg.OAuthConfig.Issuer != "" {
 		issuer, err := claims.GetIssuer()
 		if err != nil {
 			return nil, fmt.Errorf("failed to read issuer claim: %v", err)
 		}
-		if issuer != cfg.OAuthConfig.Issuer {
+		if issuer != a.cfg.OAuthConfig.Issuer {
 			return nil, fmt.Errorf("ID token from unexpected issuer: %s", issuer)
 		}
 	}
@@ -75,7 +76,7 @@ func validateRawToken(cfg *config.Config, rawIDToken string) (jwt.MapClaims, err
 	}
 	validAudience := false
 	for _, aud := range audiences {
-		if aud == cfg.OAuthConfig.ClientID {
+		if aud == a.cfg.OAuthConfig.ClientID {
 			validAudience = true
 			break
 		}

--- a/internal/oauth/idtoken_test.go
+++ b/internal/oauth/idtoken_test.go
@@ -28,10 +28,9 @@ func TestValidateToken(t *testing.T) {
 		client = "client-123"
 	)
 
-	// Point the package-level key store at our test key.
-	orig := signingKeys
-	t.Cleanup(func() { signingKeys = orig })
-	signingKeys = &keyStore{
+	// keyStore seeded with our test key. lastRefresh is recent so an unknown kid
+	// does not trigger a (network) refresh.
+	keys := &keyStore{
 		keys:        map[string]*rsa.PublicKey{kid: &key.PublicKey},
 		lastRefresh: time.Now(),
 	}
@@ -120,7 +119,8 @@ func TestValidateToken(t *testing.T) {
 				}
 			}
 
-			claims, err := ValidateToken(cfg, req)
+			a := &Authenticator{cfg: cfg, keys: keys}
+			claims, err := a.ValidateToken(req)
 			if tc.wantErr {
 				if err == nil {
 					t.Fatalf("expected error, got nil (claims=%v)", claims)

--- a/internal/oauth/jwks.go
+++ b/internal/oauth/jwks.go
@@ -33,10 +33,6 @@ type keyStore struct {
 	lastRefresh time.Time
 }
 
-// signingKeys is populated during OIDC discovery (fetchWellKnownOIDCConfig)
-// before any token is validated.
-var signingKeys *keyStore
-
 // newKeyStore creates a key store for the given JWKS endpoint. Callers must
 // invoke refresh once to populate it before validating tokens.
 func newKeyStore(jwksURI string, httpClient *http.Client) *keyStore {

--- a/internal/oauth/oauth.go
+++ b/internal/oauth/oauth.go
@@ -19,17 +19,33 @@ import (
 	"golang.org/x/time/rate"
 )
 
-var oauthConfig *oauth2.Config
+// Authenticator holds the OIDC configuration, JWKS signing keys, and per-IP
+// rate limiters for the auth endpoints. One instance backs the running server;
+// tests construct their own.
+type Authenticator struct {
+	cfg         *config.Config
+	oauthConfig *oauth2.Config
+	keys        *keyStore
+
+	limitersMu sync.Mutex
+	limiters   map[string]*ipLimiter
+}
 
 type ipLimiter struct {
 	limiter  *rate.Limiter
 	lastSeen time.Time
 }
 
-var (
-	authLimiters   = make(map[string]*ipLimiter)
-	authLimitersMu sync.Mutex
-)
+// NewAuthenticator discovers the OIDC endpoints and JWKS, then builds the
+// oauth2 config. It performs network I/O.
+func NewAuthenticator(cfg *config.Config) (*Authenticator, error) {
+	a := &Authenticator{cfg: cfg, limiters: make(map[string]*ipLimiter)}
+	if err := a.fetchWellKnownOIDCConfig(); err != nil {
+		return nil, err
+	}
+	a.oauthConfig = setupOAuthConfig(&cfg.OAuthConfig)
+	return a, nil
+}
 
 // clientIP returns the real client IP. If the direct connection is from a
 // trusted proxy, X-Real-IP and X-Forwarded-For headers are consulted instead.
@@ -58,66 +74,72 @@ func clientIP(r *http.Request, trustedProxies []*net.IPNet) string {
 	return host
 }
 
-// getAuthLimiter returns a rate limiter for the given IP, creating one if needed.
+// authLimiter returns a rate limiter for the given IP, creating one if needed.
 // Allows 5 requests per minute with a burst of 5.
-func getAuthLimiter(ip string) *rate.Limiter {
-	authLimitersMu.Lock()
-	defer authLimitersMu.Unlock()
+func (a *Authenticator) authLimiter(ip string) *rate.Limiter {
+	a.limitersMu.Lock()
+	defer a.limitersMu.Unlock()
 
-	l, ok := authLimiters[ip]
+	l, ok := a.limiters[ip]
 	if !ok {
 		l = &ipLimiter{limiter: rate.NewLimiter(rate.Every(time.Minute/5), 5)}
-		authLimiters[ip] = l
+		a.limiters[ip] = l
 	}
 	l.lastSeen = time.Now()
 	return l.limiter
 }
 
-// cleanupAuthLimiters removes entries not seen in the last 10 minutes.
-func cleanupAuthLimiters() {
+// cleanupLimiters removes entries not seen in the last 10 minutes.
+func (a *Authenticator) cleanupLimiters() {
 	for {
 		time.Sleep(5 * time.Minute)
-		authLimitersMu.Lock()
-		for ip, l := range authLimiters {
+		a.limitersMu.Lock()
+		for ip, l := range a.limiters {
 			if time.Since(l.lastSeen) > 10*time.Minute {
-				delete(authLimiters, ip)
+				delete(a.limiters, ip)
 			}
 		}
-		authLimitersMu.Unlock()
+		a.limitersMu.Unlock()
 	}
 }
 
-func RegisterOAuthHandlers(mux *http.ServeMux, cfg *config.Config) {
-	if cfg.AuthEnabled {
-		// Fetch and parse the well-known OIDC config before building the
-		// oauth2.Config so discovered auth/token endpoints are included.
-		err := fetchWellKnownOIDCConfig(cfg)
-		if err != nil {
-			log.Fatalf("Failed to fetch JWKS: %v", err)
-		}
-
-		oauthConfig = setupOAuthConfig(&cfg.OAuthConfig)
-
-		go cleanupAuthLimiters()
-
-		mux.HandleFunc(cfg.ContextRoot+"login", func(w http.ResponseWriter, r *http.Request) {
-			if !getAuthLimiter(clientIP(r, cfg.TrustedProxies)).Allow() {
-				http.Error(w, "Too Many Requests", http.StatusTooManyRequests)
-				return
-			}
-			handleLogin(cfg, w, r)
-		})
-		mux.HandleFunc(cfg.ContextRoot+"callback", func(w http.ResponseWriter, r *http.Request) {
-			if !getAuthLimiter(clientIP(r, cfg.TrustedProxies)).Allow() {
-				http.Error(w, "Too Many Requests", http.StatusTooManyRequests)
-				return
-			}
-			handleCallback(cfg, w, r)
-		})
-		mux.HandleFunc(cfg.ContextRoot+"logout", func(w http.ResponseWriter, r *http.Request) {
-			handleLogout(cfg, w, r)
-		})
+// RegisterOAuthHandlers builds the Authenticator and wires its endpoints onto
+// mux when authentication is enabled. It returns the Authenticator (whose
+// ValidateToken the WebSocket handler uses), or nil when auth is disabled.
+func RegisterOAuthHandlers(mux *http.ServeMux, cfg *config.Config) *Authenticator {
+	if !cfg.AuthEnabled {
+		return nil
 	}
+
+	auth, err := NewAuthenticator(cfg)
+	if err != nil {
+		log.Fatalf("Failed to initialize authentication: %v", err)
+	}
+	auth.register(mux)
+	return auth
+}
+
+// register wires the auth endpoints onto mux and starts the limiter cleanup.
+func (a *Authenticator) register(mux *http.ServeMux) {
+	go a.cleanupLimiters()
+
+	mux.HandleFunc(a.cfg.ContextRoot+"login", func(w http.ResponseWriter, r *http.Request) {
+		if !a.authLimiter(clientIP(r, a.cfg.TrustedProxies)).Allow() {
+			http.Error(w, "Too Many Requests", http.StatusTooManyRequests)
+			return
+		}
+		a.handleLogin(w, r)
+	})
+	mux.HandleFunc(a.cfg.ContextRoot+"callback", func(w http.ResponseWriter, r *http.Request) {
+		if !a.authLimiter(clientIP(r, a.cfg.TrustedProxies)).Allow() {
+			http.Error(w, "Too Many Requests", http.StatusTooManyRequests)
+			return
+		}
+		a.handleCallback(w, r)
+	})
+	mux.HandleFunc(a.cfg.ContextRoot+"logout", func(w http.ResponseWriter, r *http.Request) {
+		a.handleLogout(w, r)
+	})
 }
 
 func setupOAuthConfig(cfg *config.OAuthConfig) *oauth2.Config {
@@ -133,7 +155,7 @@ func setupOAuthConfig(cfg *config.OAuthConfig) *oauth2.Config {
 	}
 }
 
-func handleLogin(cfg *config.Config, w http.ResponseWriter, r *http.Request) {
+func (a *Authenticator) handleLogin(w http.ResponseWriter, r *http.Request) {
 	state, err := generateSecureRandomString(32)
 	if err != nil {
 		http.Error(w, fmt.Sprintf("Failed to generate state: %v", err), http.StatusInternalServerError)
@@ -148,16 +170,16 @@ func handleLogin(cfg *config.Config, w http.ResponseWriter, r *http.Request) {
 	// state binds the callback to this browser (CSRF); nonce binds the issued
 	// ID token to this login flow (replay protection) and is validated against
 	// the token's nonce claim in the callback.
-	url := oauthConfig.AuthCodeURL(state, oauth2.SetAuthURLParam("nonce", nonce))
-	setFlowCookie(cfg, w, "state", state)
-	setFlowCookie(cfg, w, "nonce", nonce)
+	url := a.oauthConfig.AuthCodeURL(state, oauth2.SetAuthURLParam("nonce", nonce))
+	setFlowCookie(a.cfg, w, "state", state)
+	setFlowCookie(a.cfg, w, "nonce", nonce)
 	http.Redirect(w, r, url, http.StatusTemporaryRedirect)
 }
 
-func handleCallback(cfg *config.Config, w http.ResponseWriter, r *http.Request) {
+func (a *Authenticator) handleCallback(w http.ResponseWriter, r *http.Request) {
 	stateCookie, err := r.Cookie("state")
 	if err != nil || subtle.ConstantTimeCompare([]byte(stateCookie.Value), []byte(r.URL.Query().Get("state"))) != 1 {
-		clearFlowCookies(cfg, w)
+		clearFlowCookies(a.cfg, w)
 		http.Error(w, "Invalid state", http.StatusBadRequest)
 		return
 	}
@@ -168,58 +190,59 @@ func handleCallback(cfg *config.Config, w http.ResponseWriter, r *http.Request) 
 	defer cancel()
 
 	code := r.URL.Query().Get("code")
-	token, err := oauthConfig.Exchange(ctx, code)
+	token, err := a.oauthConfig.Exchange(ctx, code)
 	if err != nil {
-		clearFlowCookies(cfg, w)
+		clearFlowCookies(a.cfg, w)
 		http.Error(w, fmt.Sprintf("Failed to exchange token: %v", err), http.StatusInternalServerError)
 		return
 	}
 
 	rawIDToken, ok := token.Extra("id_token").(string)
 	if !ok {
-		clearFlowCookies(cfg, w)
+		clearFlowCookies(a.cfg, w)
 		http.Error(w, "No id_token found", http.StatusInternalServerError)
 		return
 	}
 
 	// Validate the ID token and bind it to this login flow via the nonce, so a
 	// token captured or replayed from a different flow cannot be used here.
-	claims, err := validateRawToken(cfg, rawIDToken)
+	claims, err := a.validateRawToken(rawIDToken)
 	if err != nil {
-		clearFlowCookies(cfg, w)
+		clearFlowCookies(a.cfg, w)
 		log.Printf("Callback ID token validation failed: %s %v", r.RemoteAddr, err)
 		http.Error(w, "Invalid ID token", http.StatusUnauthorized)
 		return
 	}
 	nonceCookie, err := r.Cookie("nonce")
 	if err != nil {
-		clearFlowCookies(cfg, w)
+		clearFlowCookies(a.cfg, w)
 		http.Error(w, "Missing nonce", http.StatusBadRequest)
 		return
 	}
 	tokenNonce, _ := claims["nonce"].(string)
 	if tokenNonce == "" || subtle.ConstantTimeCompare([]byte(tokenNonce), []byte(nonceCookie.Value)) != 1 {
-		clearFlowCookies(cfg, w)
+		clearFlowCookies(a.cfg, w)
 		log.Printf("Callback nonce mismatch: %s", r.RemoteAddr)
 		http.Error(w, "Invalid nonce", http.StatusBadRequest)
 		return
 	}
 
-	clearFlowCookies(cfg, w)
+	clearFlowCookies(a.cfg, w)
 
 	http.SetCookie(w, &http.Cookie{
 		Name:     "id_token",
 		Value:    rawIDToken,
-		MaxAge:   cfg.OAuthConfig.SessionMaxAge,
-		Path:     cfg.ContextRoot,
+		MaxAge:   a.cfg.OAuthConfig.SessionMaxAge,
+		Path:     a.cfg.ContextRoot,
 		HttpOnly: true,
 		Secure:   true,
 		SameSite: http.SameSiteStrictMode,
 	})
-	http.Redirect(w, r, cfg.ContextRoot, http.StatusTemporaryRedirect)
+	http.Redirect(w, r, a.cfg.ContextRoot, http.StatusTemporaryRedirect)
 }
 
-func fetchWellKnownOIDCConfig(cfg *config.Config) error {
+func (a *Authenticator) fetchWellKnownOIDCConfig() error {
+	cfg := a.cfg
 	httpClient := &http.Client{Timeout: 10 * time.Second}
 
 	wellKnownURL := cfg.OAuthConfig.OIDCWellKnownURL
@@ -258,11 +281,11 @@ func fetchWellKnownOIDCConfig(cfg *config.Config) error {
 		return fmt.Errorf("well-known configuration provided no jwks_uri")
 	}
 
-	signingKeys = newKeyStore(discovery.JWKSURI, httpClient)
-	if err := signingKeys.refresh(); err != nil {
+	a.keys = newKeyStore(discovery.JWKSURI, httpClient)
+	if err := a.keys.refresh(); err != nil {
 		return err
 	}
-	go signingKeys.refreshLoop()
+	go a.keys.refreshLoop()
 
 	return nil
 }
@@ -270,18 +293,18 @@ func fetchWellKnownOIDCConfig(cfg *config.Config) error {
 // handleLogout clears the session cookie and returns the user to the app,
 // which will then prompt for login again. This is a local logout; it does not
 // terminate the session at the identity provider.
-func handleLogout(cfg *config.Config, w http.ResponseWriter, r *http.Request) {
+func (a *Authenticator) handleLogout(w http.ResponseWriter, r *http.Request) {
 	http.SetCookie(w, &http.Cookie{
 		Name:     "id_token",
 		Value:    "",
-		Path:     cfg.ContextRoot,
+		Path:     a.cfg.ContextRoot,
 		HttpOnly: true,
 		Secure:   true,
 		SameSite: http.SameSiteStrictMode,
 		Expires:  time.Unix(0, 0),
 		MaxAge:   -1,
 	})
-	http.Redirect(w, r, cfg.ContextRoot, http.StatusTemporaryRedirect)
+	http.Redirect(w, r, a.cfg.ContextRoot, http.StatusTemporaryRedirect)
 }
 
 // setFlowCookie sets a short-lived cookie used during the OAuth redirect flow.

--- a/internal/oauth/oauth_test.go
+++ b/internal/oauth/oauth_test.go
@@ -130,13 +130,6 @@ func TestRegisterOAuthHandlersUsesDiscoveredEndpoints(t *testing.T) {
 	}))
 	defer discovery.Close()
 
-	origOAuthConfig := oauthConfig
-	origSigningKeys := signingKeys
-	t.Cleanup(func() {
-		oauthConfig = origOAuthConfig
-		signingKeys = origSigningKeys
-	})
-
 	cfg := &config.Config{
 		ContextRoot: "/",
 		AuthEnabled: true,
@@ -148,13 +141,16 @@ func TestRegisterOAuthHandlersUsesDiscoveredEndpoints(t *testing.T) {
 	}
 
 	mux := http.NewServeMux()
-	RegisterOAuthHandlers(mux, cfg)
-
-	if oauthConfig.Endpoint.AuthURL != "https://issuer.example.com/auth" {
-		t.Fatalf("AuthURL = %q, want discovered endpoint", oauthConfig.Endpoint.AuthURL)
+	auth := RegisterOAuthHandlers(mux, cfg)
+	if auth == nil {
+		t.Fatal("expected an Authenticator when auth is enabled")
 	}
-	if oauthConfig.Endpoint.TokenURL != "https://issuer.example.com/token" {
-		t.Fatalf("TokenURL = %q, want discovered endpoint", oauthConfig.Endpoint.TokenURL)
+
+	if auth.oauthConfig.Endpoint.AuthURL != "https://issuer.example.com/auth" {
+		t.Fatalf("AuthURL = %q, want discovered endpoint", auth.oauthConfig.Endpoint.AuthURL)
+	}
+	if auth.oauthConfig.Endpoint.TokenURL != "https://issuer.example.com/token" {
+		t.Fatalf("TokenURL = %q, want discovered endpoint", auth.oauthConfig.Endpoint.TokenURL)
 	}
 
 	req := httptest.NewRequest(http.MethodGet, "/login", nil)


### PR DESCRIPTION
> **Stacked on #52** (stage 2), which is stacked on #51 (stage 1). Merge in order; bases retarget automatically as each lands.

Third slice of #13. Retires the oauth package globals into an `Authenticator`, using the decoupled-validator approach (option i).

**What changed**
- `oauthConfig`, the JWKS `keyStore` (`signingKeys`), and the per-IP rate limiters are now fields of an `Authenticator`. The login/callback/logout handlers, `ValidateToken`/`validateRawToken`, the limiter, and OIDC discovery are Authenticator methods. `RegisterOAuthHandlers` builds one and returns it (nil when auth is disabled).
- **Decoupled the WebSocket handler from oauth:** the docker package defines a `TokenValidator func(*http.Request) (jwt.MapClaims, error)`; the `Hub` holds one and calls it instead of `oauth.ValidateToken`. `main` wires `oauth...ValidateToken` into `RegisterDockerHandlers`. **The docker package no longer imports oauth.**
- The oauth tests now construct an `Authenticator` (injected keyStore + oauth2 config) and call its methods, instead of swapping package globals.

`go test -race ./...` green; verified end to end against a live swarm (auth-disabled path: `/healthz` 200, snapshot over `/ws`).

**Remaining for #13:** stage 4 — `/ws` + OAuth integration tests against the mux (now straightforward since both register on an injectable mux and hold their state in structs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)