### PR TITLE
#13 (stage 4): /ws + OAuth integration tests

### DIFF
--- a/internal/docker/ws_integration_test.go
+++ b/internal/docker/ws_integration_test.go
@@ -1,0 +1,90 @@
+package docker
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/golang-jwt/jwt/v5"
+	"github.com/gorilla/websocket"
+
+	"github.com/jtgasper3/swarm-visualizer/internal/config"
+)
+
+// bearerValidator accepts only "Bearer good".
+func bearerValidator(r *http.Request) (jwt.MapClaims, error) {
+	if r.Header.Get("Authorization") == "Bearer good" {
+		return jwt.MapClaims{"sub": "alice"}, nil
+	}
+	return nil, fmt.Errorf("no valid token")
+}
+
+func wsServer(t *testing.T, h *Hub) (*httptest.Server, string) {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(h.handleConnections))
+	t.Cleanup(srv.Close)
+	return srv, "ws" + strings.TrimPrefix(srv.URL, "http") + "/ws"
+}
+
+// TestWS_AuthRejectsUnauthorized verifies that, with auth enabled, a connection
+// without a valid token receives the in-band 401 message and is not registered.
+func TestWS_AuthRejectsUnauthorized(t *testing.T) {
+	cfg := &config.Config{ContextRoot: "/", AuthEnabled: true, OAuthConfig: config.OAuthConfig{UsernameClaim: "sub"}}
+	h := newHub(cfg, bearerValidator)
+	_, wsURL := wsServer(t, h)
+
+	conn, _, err := websocket.DefaultDialer.Dial(wsURL, nil) // no Authorization header
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+	defer conn.Close()
+
+	conn.SetReadDeadline(time.Now().Add(2 * time.Second))
+	_, msg, err := conn.ReadMessage()
+	if err != nil {
+		t.Fatalf("expected a 401 message, got read error: %v", err)
+	}
+	if string(msg) != "401-Unauthorized" {
+		t.Fatalf("got %q, want 401-Unauthorized", msg)
+	}
+	if c := clientCount(h); c != 0 {
+		t.Fatalf("unauthorized client must not be registered, count=%d", c)
+	}
+}
+
+// TestWS_AuthAcceptsAndDelivers verifies that an authorized connection is
+// registered and receives the current snapshot.
+func TestWS_AuthAcceptsAndDelivers(t *testing.T) {
+	cfg := &config.Config{ContextRoot: "/", AuthEnabled: true, OAuthConfig: config.OAuthConfig{UsernameClaim: "sub"}}
+	h := newHub(cfg, bearerValidator)
+	go h.runBroadcasts()
+	_, wsURL := wsServer(t, h)
+
+	// Publish a frame and wait until it has been fanned out, so a newly
+	// connecting client is seeded with it.
+	frame := []byte(`{"clusterName":"x"}`)
+	h.Publish(frame)
+	if !waitFor(t, h.Ready, time.Second) {
+		t.Fatal("frame was never fanned out")
+	}
+
+	header := http.Header{}
+	header.Set("Authorization", "Bearer good")
+	conn, _, err := websocket.DefaultDialer.Dial(wsURL, header)
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+	defer conn.Close()
+
+	conn.SetReadDeadline(time.Now().Add(2 * time.Second))
+	_, msg, err := conn.ReadMessage()
+	if err != nil {
+		t.Fatalf("authorized client got no frame: %v", err)
+	}
+	if string(msg) != string(frame) {
+		t.Fatalf("got %q, want %q", msg, frame)
+	}
+}

--- a/internal/oauth/integration_test.go
+++ b/internal/oauth/integration_test.go
@@ -1,0 +1,87 @@
+package oauth
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/jtgasper3/swarm-visualizer/internal/config"
+	"golang.org/x/oauth2"
+)
+
+// newTestAuthenticator builds an Authenticator wired for handler tests, without
+// the network discovery that NewAuthenticator performs.
+func newTestAuthenticator() *Authenticator {
+	return &Authenticator{
+		cfg: &config.Config{ContextRoot: "/"},
+		oauthConfig: &oauth2.Config{
+			ClientID: "client-1",
+			Endpoint: oauth2.Endpoint{AuthURL: "https://idp.example.com/auth"},
+		},
+		limiters: make(map[string]*ipLimiter),
+	}
+}
+
+// TestOAuthRoutes_ThroughMux exercises the registered login and logout routes
+// end to end via a ServeMux.
+func TestOAuthRoutes_ThroughMux(t *testing.T) {
+	a := newTestAuthenticator()
+	mux := http.NewServeMux()
+	a.register(mux)
+
+	// /login redirects to the IdP authorize endpoint.
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/login", nil)
+	req.RemoteAddr = "1.2.3.4:1111"
+	mux.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusTemporaryRedirect {
+		t.Fatalf("login status = %d, want %d", rr.Code, http.StatusTemporaryRedirect)
+	}
+	if loc := rr.Header().Get("Location"); !strings.HasPrefix(loc, "https://idp.example.com/auth?") {
+		t.Fatalf("login Location = %q, want IdP authorize URL", loc)
+	}
+
+	// /logout clears the session cookie.
+	rr = httptest.NewRecorder()
+	req = httptest.NewRequest(http.MethodGet, "/logout", nil)
+	req.RemoteAddr = "1.2.3.4:1111"
+	mux.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusTemporaryRedirect {
+		t.Fatalf("logout status = %d, want %d", rr.Code, http.StatusTemporaryRedirect)
+	}
+	cleared := false
+	for _, c := range rr.Result().Cookies() {
+		if c.Name == "id_token" && c.MaxAge < 0 {
+			cleared = true
+		}
+	}
+	if !cleared {
+		t.Fatal("logout did not clear the id_token cookie")
+	}
+}
+
+// TestOAuthRateLimit verifies the per-IP rate limiter on the auth endpoints
+// returns 429 once the burst is exceeded.
+func TestOAuthRateLimit(t *testing.T) {
+	a := newTestAuthenticator()
+	mux := http.NewServeMux()
+	a.register(mux)
+
+	got429 := false
+	for i := 0; i < 8; i++ {
+		rr := httptest.NewRecorder()
+		req := httptest.NewRequest(http.MethodGet, "/login", nil)
+		req.RemoteAddr = "9.9.9.9:2222"
+		mux.ServeHTTP(rr, req)
+		if rr.Code == http.StatusTooManyRequests {
+			got429 = true
+			break
+		}
+	}
+	if !got429 {
+		t.Fatal("expected a 429 after exceeding the burst limit")
+	}
+}

--- a/internal/oauth/oauth.go
+++ b/internal/oauth/oauth.go
@@ -115,14 +115,13 @@ func RegisterOAuthHandlers(mux *http.ServeMux, cfg *config.Config) *Authenticato
 	if err != nil {
 		log.Fatalf("Failed to initialize authentication: %v", err)
 	}
+	go auth.cleanupLimiters()
 	auth.register(mux)
 	return auth
 }
 
-// register wires the auth endpoints onto mux and starts the limiter cleanup.
+// register wires the auth endpoints onto mux.
 func (a *Authenticator) register(mux *http.ServeMux) {
-	go a.cleanupLimiters()
-
 	mux.HandleFunc(a.cfg.ContextRoot+"login", func(w http.ResponseWriter, r *http.Request) {
 		if !a.authLimiter(clientIP(r, a.cfg.TrustedProxies)).Allow() {
 			http.Error(w, "Too Many Requests", http.StatusTooManyRequests)


### PR DESCRIPTION
> **Stacked on #53** (stage 3) → #52 → #51. Merge in order; bases retarget as each lands. Final slice of #13.

The payoff of the refactor: now that the WebSocket fan-out and OAuth flow hold state in a `Hub`/`Authenticator` and register on an injectable mux, they can be exercised end to end.

**Added**
- **WebSocket auth (`internal/docker/ws_integration_test.go`)** — with auth enabled, an unauthorized connection receives the in-band `401-Unauthorized` message and is **not** registered; an authorized connection (via the injected `TokenValidator`) is registered and receives the current snapshot. Covers the auth-enabled `/ws` path and the validator seam, which had no integration coverage before.
- **OAuth routes (`internal/oauth/integration_test.go`)** — the `login` route registered on a mux redirects to the IdP authorize endpoint, `logout` clears the session cookie, and the per-IP rate limiter returns `429` once the burst is exceeded.
- Moved the limiter-cleanup goroutine startup from `register()` into `RegisterOAuthHandlers` so route registration can be tested without leaking the goroutine.

`go test -race ./...` green (timing-sensitive subset run ×3).

This completes the #13 series (stages 1–4): dedicated mux, docker `Hub`, oauth `Authenticator` + decoupled validator, and integration tests. Remaining package-level state is the deliberately-kept singleton/safe set (`upgrader`, atomic keepalive timings, single-goroutine `stoppedTaskCache`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)