### PR TITLE
#13 (stages 2-4): Hub, Authenticator, integration tests (recovery)

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -25,8 +25,15 @@ func main() {
 	fs := http.FileServer(http.Dir("./static"))
 	mux.Handle(contextRoot, http.StripPrefix(contextRoot, fs))
 
-	hub := docker.RegisterDockerHandlers(mux, cfg)
-	oauth.RegisterOAuthHandlers(mux, cfg)
+	// Register auth first so its token validator can be handed to the WebSocket
+	// handler. auth is nil when authentication is disabled.
+	auth := oauth.RegisterOAuthHandlers(mux, cfg)
+	var validate docker.TokenValidator
+	if auth != nil {
+		validate = auth.ValidateToken
+	}
+
+	hub := docker.RegisterDockerHandlers(mux, cfg, validate)
 
 	// Unauthenticated readiness endpoint at a fixed path (independent of
 	// CONTEXT_ROOT) for orchestrator health checks.

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -25,12 +25,12 @@ func main() {
 	fs := http.FileServer(http.Dir("./static"))
 	mux.Handle(contextRoot, http.StripPrefix(contextRoot, fs))
 
-	docker.RegisterDockerHandlers(mux, cfg)
+	hub := docker.RegisterDockerHandlers(mux, cfg)
 	oauth.RegisterOAuthHandlers(mux, cfg)
 
 	// Unauthenticated readiness endpoint at a fixed path (independent of
 	// CONTEXT_ROOT) for orchestrator health checks.
-	mux.Handle("/healthz", healthzHandler(docker.Ready))
+	mux.Handle("/healthz", healthzHandler(hub.Ready))
 
 	server := &http.Server{
 		Addr:              ":" + cfg.ListenerPort,

--- a/internal/docker/handlers.go
+++ b/internal/docker/handlers.go
@@ -8,11 +8,16 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/golang-jwt/jwt/v5"
 	"github.com/gorilla/websocket"
 
 	"github.com/jtgasper3/swarm-visualizer/internal/config"
-	"github.com/jtgasper3/swarm-visualizer/internal/oauth"
 )
+
+// TokenValidator validates the ID token on an incoming request and returns its
+// claims. It decouples the WebSocket handler from the oauth package; the running
+// server wires in oauth.Authenticator.ValidateToken.
+type TokenValidator func(*http.Request) (jwt.MapClaims, error)
 
 var upgrader = websocket.Upgrader{
 	CheckOrigin: func(r *http.Request) bool {
@@ -34,6 +39,9 @@ const wsWriteTimeout = 5 * time.Second
 // to them. One Hub backs the running server; tests construct their own.
 type Hub struct {
 	cfg *config.Config
+	// validate authenticates a connection when cfg.AuthEnabled. It is nil when
+	// auth is disabled.
+	validate TokenValidator
 
 	mu sync.Mutex
 	// clients is the set of connected clients.
@@ -51,10 +59,12 @@ type Hub struct {
 	broadcast chan []byte
 }
 
-// newHub creates a Hub configured from cfg.
-func newHub(cfg *config.Config) *Hub {
+// newHub creates a Hub configured from cfg. validate may be nil when auth is
+// disabled.
+func newHub(cfg *config.Config, validate TokenValidator) *Hub {
 	return &Hub{
 		cfg:        cfg,
+		validate:   validate,
 		clients:    make(map[*wsClient]struct{}),
 		maxClients: cfg.MaxWSConnections,
 		broadcast:  make(chan []byte, 1),
@@ -103,8 +113,8 @@ type wsClient struct {
 	send chan []byte
 }
 
-func RegisterDockerHandlers(mux *http.ServeMux, cfg *config.Config) *Hub {
-	hub := newHub(cfg)
+func RegisterDockerHandlers(mux *http.ServeMux, cfg *config.Config, validate TokenValidator) *Hub {
+	hub := newHub(cfg, validate)
 
 	src, err := newMobySource()
 	if err != nil {
@@ -138,7 +148,7 @@ func (h *Hub) handleConnections(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if cfg.AuthEnabled {
-		claims, err := oauth.ValidateToken(cfg, r)
+		claims, err := h.validate(r)
 		if err != nil {
 			ws.SetWriteDeadline(time.Now().Add(wsWriteTimeout))
 			ws.WriteMessage(websocket.TextMessage, []byte("401-Unauthorized"))

--- a/internal/docker/handlers.go
+++ b/internal/docker/handlers.go
@@ -14,34 +14,66 @@ import (
 	"github.com/jtgasper3/swarm-visualizer/internal/oauth"
 )
 
-var (
-	upgrader = websocket.Upgrader{
-		CheckOrigin: func(r *http.Request) bool {
-			origin := r.Header.Get("Origin")
-			if origin == "" {
-				return true // non-browser clients (curl, native apps)
-			}
-			u, err := url.Parse(origin)
-			if err != nil {
-				return false
-			}
-			return u.Host == r.Host
-		},
-	}
-	clientsMu sync.Mutex
-	clients   = make(map[*wsClient]struct{})
-	// lastFanned is the most recent frame handed to handleBroadcasts, guarded by
-	// clientsMu. A newly registered client is seeded with it (under the same
-	// lock) so its seed is never newer than a frame still queued for fan-out,
-	// which would otherwise make the client briefly roll back to older state.
-	lastFanned []byte
-	// maxClients caps the number of concurrent WebSocket connections to bound
-	// resource use. 0 means unlimited; it is set from config in
-	// RegisterDockerHandlers.
-	maxClients int
-)
+var upgrader = websocket.Upgrader{
+	CheckOrigin: func(r *http.Request) bool {
+		origin := r.Header.Get("Origin")
+		if origin == "" {
+			return true // non-browser clients (curl, native apps)
+		}
+		u, err := url.Parse(origin)
+		if err != nil {
+			return false
+		}
+		return u.Host == r.Host
+	},
+}
 
 const wsWriteTimeout = 5 * time.Second
+
+// Hub owns the set of connected WebSocket clients and fans out snapshot frames
+// to them. One Hub backs the running server; tests construct their own.
+type Hub struct {
+	cfg *config.Config
+
+	mu sync.Mutex
+	// clients is the set of connected clients.
+	clients map[*wsClient]struct{}
+	// lastFanned is the most recent frame handed out, guarded by mu. A newly
+	// registered client is seeded with it (under the same lock) so its seed is
+	// never newer than a frame still queued for fan-out, which would otherwise
+	// make the client briefly roll back to older state.
+	lastFanned []byte
+	// maxClients caps concurrent connections to bound resource use. 0 means
+	// unlimited.
+	maxClients int
+
+	// broadcast carries marshalled snapshots from the inspector to runBroadcasts.
+	broadcast chan []byte
+}
+
+// newHub creates a Hub configured from cfg.
+func newHub(cfg *config.Config) *Hub {
+	return &Hub{
+		cfg:        cfg,
+		clients:    make(map[*wsClient]struct{}),
+		maxClients: cfg.MaxWSConnections,
+		broadcast:  make(chan []byte, 1),
+	}
+}
+
+// Ready reports whether at least one snapshot has been fanned out, i.e. the
+// Docker API is reachable and data has been published. It stays true once the
+// first frame is sent, so it does not flap on transient errors.
+func (h *Hub) Ready() bool {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	return h.lastFanned != nil
+}
+
+// Publish hands a marshalled snapshot to the fan-out goroutine.
+func (h *Hub) Publish(frame []byte) {
+	h.broadcast <- frame
+}
 
 // Keepalive timings: a ping is sent every pingPeriod(), and the read side must
 // see a pong (or any frame) within pongWait() or the peer is considered dead
@@ -71,28 +103,30 @@ type wsClient struct {
 	send chan []byte
 }
 
-func RegisterDockerHandlers(mux *http.ServeMux, cfg *config.Config) {
-	maxClients = cfg.MaxWSConnections
+func RegisterDockerHandlers(mux *http.ServeMux, cfg *config.Config) *Hub {
+	hub := newHub(cfg)
 
 	src, err := newMobySource()
 	if err != nil {
 		log.Fatal("Docker client error:", err)
 	}
 
-	go inspectSwarmServices(cfg, src)
-	go handleBroadcasts()
+	go inspectSwarmServices(cfg, src, hub)
+	go hub.runBroadcasts()
 
-	mux.HandleFunc(cfg.ContextRoot+"ws", func(w http.ResponseWriter, r *http.Request) {
-		handleConnections(cfg, w, r)
-	})
+	mux.HandleFunc(cfg.ContextRoot+"ws", hub.handleConnections)
+
+	return hub
 }
 
-func handleConnections(cfg *config.Config, w http.ResponseWriter, r *http.Request) {
+func (h *Hub) handleConnections(w http.ResponseWriter, r *http.Request) {
+	cfg := h.cfg
+
 	// Shed load before the WebSocket handshake when already at capacity. This
-	// is best effort; registerClient performs the authoritative check.
-	if atClientCapacity() {
+	// is best effort; register performs the authoritative check.
+	if h.atCapacity() {
 		http.Error(w, "Too many connections", http.StatusServiceUnavailable)
-		log.Printf("Connection rejected, server at capacity (%d): %s", maxClients, r.RemoteAddr)
+		log.Printf("Connection rejected, server at capacity (%d): %s", h.maxClients, r.RemoteAddr)
 		return
 	}
 
@@ -119,9 +153,9 @@ func handleConnections(cfg *config.Config, w http.ResponseWriter, r *http.Reques
 
 	c := &wsClient{conn: ws, send: make(chan []byte, 1)}
 
-	if !registerClient(c) {
+	if !h.register(c) {
 		// Capacity was reached between the pre-upgrade check and here.
-		log.Printf("Connection rejected, server at capacity (%d): %s", maxClients, r.RemoteAddr)
+		log.Printf("Connection rejected, server at capacity (%d): %s", h.maxClients, r.RemoteAddr)
 		ws.Close()
 		return
 	}
@@ -147,7 +181,7 @@ func handleConnections(cfg *config.Config, w http.ResponseWriter, r *http.Reques
 			break
 		}
 	}
-	unregisterClient(c)
+	h.unregister(c)
 }
 
 // writePump owns every write to the connection: snapshot frames from send and
@@ -183,27 +217,27 @@ func (c *wsClient) writePump() {
 	}
 }
 
-// atClientCapacity reports whether the concurrent connection limit is reached.
-func atClientCapacity() bool {
-	if maxClients <= 0 {
+// atCapacity reports whether the concurrent connection limit is reached.
+func (h *Hub) atCapacity() bool {
+	if h.maxClients <= 0 {
 		return false
 	}
-	clientsMu.Lock()
-	defer clientsMu.Unlock()
-	return len(clients) >= maxClients
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	return len(h.clients) >= h.maxClients
 }
 
-// registerClient adds the client to the registry and seeds it with the latest
+// register adds the client to the registry and seeds it with the latest
 // snapshot, all under the broadcast lock. It returns false (registering
 // nothing) if the concurrent connection cap is reached.
-func registerClient(c *wsClient) bool {
-	clientsMu.Lock()
-	defer clientsMu.Unlock()
+func (h *Hub) register(c *wsClient) bool {
+	h.mu.Lock()
+	defer h.mu.Unlock()
 
-	if maxClients > 0 && len(clients) >= maxClients {
+	if h.maxClients > 0 && len(h.clients) >= h.maxClients {
 		return false
 	}
-	clients[c] = struct{}{}
+	h.clients[c] = struct{}{}
 
 	// Seed the most recently fanned-out frame, if any, under the same lock that
 	// guards broadcasts. This keeps registration and seeding atomic with respect
@@ -211,34 +245,35 @@ func registerClient(c *wsClient) bool {
 	// "null" frame before the first poll, and is never seeded with a frame newer
 	// than one still queued for fan-out (which would cause a visible rollback).
 	// The send buffer was just created with cap 1, so this never blocks.
-	if lastFanned != nil {
-		c.send <- lastFanned
+	if h.lastFanned != nil {
+		c.send <- h.lastFanned
 	}
 	return true
 }
 
-func unregisterClient(c *wsClient) {
-	clientsMu.Lock()
-	if _, ok := clients[c]; ok {
-		delete(clients, c)
+func (h *Hub) unregister(c *wsClient) {
+	h.mu.Lock()
+	if _, ok := h.clients[c]; ok {
+		delete(h.clients, c)
 		// Closing send terminates writePump's range. Safe against the
 		// broadcaster because it only enqueues to clients still in the map
 		// and holds the same lock.
 		close(c.send)
 	}
-	clientsMu.Unlock()
+	h.mu.Unlock()
 }
 
-func handleBroadcasts() {
-	for msg := range broadcast {
-		clientsMu.Lock()
+// runBroadcasts fans out each published frame to all connected clients.
+func (h *Hub) runBroadcasts() {
+	for msg := range h.broadcast {
+		h.mu.Lock()
 		// Record the frame being fanned out so a client registering concurrently
 		// is seeded with this frame (or a newer one), never a stale one.
-		lastFanned = msg
-		for c := range clients {
+		h.lastFanned = msg
+		for c := range h.clients {
 			enqueue(c, msg)
 		}
-		clientsMu.Unlock()
+		h.mu.Unlock()
 	}
 }
 

--- a/internal/docker/handlers_test.go
+++ b/internal/docker/handlers_test.go
@@ -9,7 +9,7 @@ import (
 
 // TestRegisterClient_EnforcesCap verifies the concurrent connection cap.
 func TestRegisterClient_EnforcesCap(t *testing.T) {
-	h := newHub(&config.Config{MaxWSConnections: 2})
+	h := newHub(&config.Config{MaxWSConnections: 2}, nil)
 
 	c1 := &wsClient{send: make(chan []byte, 1)}
 	c2 := &wsClient{send: make(chan []byte, 1)}
@@ -38,7 +38,7 @@ func TestRegisterClient_EnforcesCap(t *testing.T) {
 // TestRegisterClient_SeedsLatestSnapshot verifies a newly registered client is
 // seeded with the most recent snapshot.
 func TestRegisterClient_SeedsLatestSnapshot(t *testing.T) {
-	h := newHub(&config.Config{})
+	h := newHub(&config.Config{}, nil)
 
 	payload := []byte(`{"clusterName":"test"}`)
 	h.lastFanned = payload
@@ -59,7 +59,7 @@ func TestRegisterClient_SeedsLatestSnapshot(t *testing.T) {
 // TestRegisterClient_NoSeedBeforeFirstSnapshot verifies that a client that
 // connects before any data has been produced is not sent a "null" frame.
 func TestRegisterClient_NoSeedBeforeFirstSnapshot(t *testing.T) {
-	h := newHub(&config.Config{})
+	h := newHub(&config.Config{}, nil)
 
 	c := &wsClient{send: make(chan []byte, 1)}
 	h.register(c)

--- a/internal/docker/handlers_test.go
+++ b/internal/docker/handlers_test.go
@@ -3,46 +3,34 @@ package docker
 import (
 	"testing"
 	"time"
-)
 
-// resetClientState clears the package-level client registry and seed snapshot
-// so a test starts from a known state.
-func resetClientState(t *testing.T) {
-	t.Helper()
-	t.Cleanup(func() {
-		clientsMu.Lock()
-		clients = make(map[*wsClient]struct{})
-		lastFanned = nil
-		clientsMu.Unlock()
-		maxClients = 0
-	})
-}
+	"github.com/jtgasper3/swarm-visualizer/internal/config"
+)
 
 // TestRegisterClient_EnforcesCap verifies the concurrent connection cap.
 func TestRegisterClient_EnforcesCap(t *testing.T) {
-	resetClientState(t)
-	maxClients = 2
+	h := newHub(&config.Config{MaxWSConnections: 2})
 
 	c1 := &wsClient{send: make(chan []byte, 1)}
 	c2 := &wsClient{send: make(chan []byte, 1)}
 	c3 := &wsClient{send: make(chan []byte, 1)}
 
-	if !registerClient(c1) || !registerClient(c2) {
+	if !h.register(c1) || !h.register(c2) {
 		t.Fatal("expected the first two clients to register")
 	}
-	if registerClient(c3) {
+	if h.register(c3) {
 		t.Fatal("expected the third client to be rejected at capacity")
 	}
-	if atClientCapacity() != true {
-		t.Fatal("expected atClientCapacity to report full")
+	if !h.atCapacity() {
+		t.Fatal("expected atCapacity to report full")
 	}
 
 	// Freeing a slot allows a new client in.
-	unregisterClient(c1)
-	if atClientCapacity() {
+	h.unregister(c1)
+	if h.atCapacity() {
 		t.Fatal("expected capacity after unregister")
 	}
-	if !registerClient(c3) {
+	if !h.register(c3) {
 		t.Fatal("expected registration to succeed after a slot freed")
 	}
 }
@@ -50,13 +38,13 @@ func TestRegisterClient_EnforcesCap(t *testing.T) {
 // TestRegisterClient_SeedsLatestSnapshot verifies a newly registered client is
 // seeded with the most recent snapshot.
 func TestRegisterClient_SeedsLatestSnapshot(t *testing.T) {
-	resetClientState(t)
+	h := newHub(&config.Config{})
 
 	payload := []byte(`{"clusterName":"test"}`)
-	lastFanned = payload
+	h.lastFanned = payload
 
 	c := &wsClient{send: make(chan []byte, 1)}
-	registerClient(c)
+	h.register(c)
 
 	select {
 	case got := <-c.send:
@@ -71,11 +59,10 @@ func TestRegisterClient_SeedsLatestSnapshot(t *testing.T) {
 // TestRegisterClient_NoSeedBeforeFirstSnapshot verifies that a client that
 // connects before any data has been produced is not sent a "null" frame.
 func TestRegisterClient_NoSeedBeforeFirstSnapshot(t *testing.T) {
-	resetClientState(t)
-	lastFanned = nil
+	h := newHub(&config.Config{})
 
 	c := &wsClient{send: make(chan []byte, 1)}
-	registerClient(c)
+	h.register(c)
 
 	select {
 	case got := <-c.send:

--- a/internal/docker/inspect.go
+++ b/internal/docker/inspect.go
@@ -8,7 +8,6 @@ import (
 	"reflect"
 	"slices"
 	"strings"
-	"sync/atomic"
 	"time"
 
 	"github.com/jtgasper3/swarm-visualizer/internal"
@@ -33,21 +32,8 @@ type cachedTask struct {
 	firstSeen time.Time
 }
 
-var (
-	broadcast = make(chan []byte, 1)
-	// lastBroadcastedData holds the most recent snapshot for change detection;
-	// it is written and read only by the single inspectSwarmServices goroutine.
-	lastBroadcastedData atomic.Pointer[SwarmData]
-	// stoppedTaskCache is only accessed from the single inspectSwarmServices goroutine.
-	stoppedTaskCache = make(map[string]cachedTask)
-)
-
-// Ready reports whether at least one successful swarm inspection has completed,
-// i.e. the Docker API is reachable and data has been published. It stays true
-// once the first poll succeeds, so it does not flap on transient errors.
-func Ready() bool {
-	return lastBroadcastedData.Load() != nil
-}
+// stoppedTaskCache is only accessed from the single inspectSwarmServices goroutine.
+var stoppedTaskCache = make(map[string]cachedTask)
 
 // swarmSource is the subset of the Docker API the inspector needs. It is an
 // interface so tests can substitute a fake daemon for the real client.
@@ -123,7 +109,7 @@ const (
 // fields and is therefore idempotent; re-applying it to a cached (already
 // cleared) slice that is also referenced by the previously published snapshot
 // leaves that snapshot's bytes unchanged, so change detection stays correct.
-func inspectSwarmServices(cfg *config.Config, src swarmSource) {
+func inspectSwarmServices(cfg *config.Config, src swarmSource, hub *Hub) {
 	ctx := context.Background()
 
 	var (
@@ -134,6 +120,10 @@ func inspectSwarmServices(cfg *config.Config, src swarmSource) {
 
 		haveStructural bool
 		haveTasks      bool
+
+		// lastPublished is the previous snapshot, kept for change detection. It is
+		// only touched by this single goroutine.
+		lastPublished *SwarmData
 	)
 
 	refreshStructural := func() bool {
@@ -179,14 +169,14 @@ func inspectSwarmServices(cfg *config.Config, src swarmSource) {
 			}
 		}
 
-		if prev := lastBroadcastedData.Load(); prev == nil || !reflect.DeepEqual(data, *prev) {
+		if lastPublished == nil || !reflect.DeepEqual(data, *lastPublished) {
 			jsonBytes, err := json.Marshal(data)
 			if err != nil {
 				log.Println("Error marshalling combined data:", err)
 				return
 			}
-			lastBroadcastedData.Store(&data)
-			broadcast <- jsonBytes
+			lastPublished = &data
+			hub.Publish(jsonBytes)
 		}
 	}
 

--- a/internal/docker/inspect_test.go
+++ b/internal/docker/inspect_test.go
@@ -9,17 +9,15 @@ import (
 )
 
 func TestReady(t *testing.T) {
-	orig := lastBroadcastedData.Load()
-	t.Cleanup(func() { lastBroadcastedData.Store(orig) })
+	h := newHub(&config.Config{})
 
-	lastBroadcastedData.Store(nil)
-	if Ready() {
-		t.Fatal("expected not ready before the first successful poll")
+	if h.Ready() {
+		t.Fatal("expected not ready before the first frame is fanned out")
 	}
 
-	lastBroadcastedData.Store(&SwarmData{})
-	if !Ready() {
-		t.Fatal("expected ready once data has been published")
+	h.lastFanned = []byte(`{}`)
+	if !h.Ready() {
+		t.Fatal("expected ready once a frame has been fanned out")
 	}
 }
 

--- a/internal/docker/inspect_test.go
+++ b/internal/docker/inspect_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 func TestReady(t *testing.T) {
-	h := newHub(&config.Config{})
+	h := newHub(&config.Config{}, nil)
 
 	if h.Ready() {
 		t.Fatal("expected not ready before the first frame is fanned out")

--- a/internal/docker/keepalive_test.go
+++ b/internal/docker/keepalive_test.go
@@ -49,7 +49,7 @@ func waitFor(t *testing.T, cond func() bool, timeout time.Duration) bool {
 func TestKeepalive_ReapsUnresponsivePeer(t *testing.T) {
 	setKeepalive(t, 50*time.Millisecond, 250*time.Millisecond)
 
-	h := newHub(&config.Config{ContextRoot: "/"})
+	h := newHub(&config.Config{ContextRoot: "/"}, nil)
 	srv := httptest.NewServer(http.HandlerFunc(h.handleConnections))
 	defer srv.Close()
 
@@ -77,7 +77,7 @@ func TestKeepalive_ResponsivePeerStaysConnected(t *testing.T) {
 	// deadline open even under the scheduling jitter of the race detector.
 	setKeepalive(t, 50*time.Millisecond, 600*time.Millisecond)
 
-	h := newHub(&config.Config{ContextRoot: "/"})
+	h := newHub(&config.Config{ContextRoot: "/"}, nil)
 	srv := httptest.NewServer(http.HandlerFunc(h.handleConnections))
 	defer srv.Close()
 

--- a/internal/docker/keepalive_test.go
+++ b/internal/docker/keepalive_test.go
@@ -12,10 +12,10 @@ import (
 	"github.com/jtgasper3/swarm-visualizer/internal/config"
 )
 
-func clientCount() int {
-	clientsMu.Lock()
-	defer clientsMu.Unlock()
-	return len(clients)
+func clientCount(h *Hub) int {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	return len(h.clients)
 }
 
 // setKeepalive overrides the ping/pong timings for the duration of a test.
@@ -47,13 +47,10 @@ func waitFor(t *testing.T, cond func() bool, timeout time.Duration) bool {
 // that does not read also never auto-replies to pings, which simulates a peer
 // that has silently vanished.
 func TestKeepalive_ReapsUnresponsivePeer(t *testing.T) {
-	resetClientState(t)
 	setKeepalive(t, 50*time.Millisecond, 250*time.Millisecond)
 
-	cfg := &config.Config{ContextRoot: "/"}
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		handleConnections(cfg, w, r)
-	}))
+	h := newHub(&config.Config{ContextRoot: "/"})
+	srv := httptest.NewServer(http.HandlerFunc(h.handleConnections))
 	defer srv.Close()
 
 	wsURL := "ws" + strings.TrimPrefix(srv.URL, "http") + "/ws"
@@ -65,26 +62,23 @@ func TestKeepalive_ReapsUnresponsivePeer(t *testing.T) {
 	// Deliberately never read from conn: the client never auto-replies to the
 	// server's pings, so the server should reap it after pongWait.
 
-	if !waitFor(t, func() bool { return clientCount() == 1 }, 2*time.Second) {
-		t.Fatalf("client never registered (count=%d)", clientCount())
+	if !waitFor(t, func() bool { return clientCount(h) == 1 }, 2*time.Second) {
+		t.Fatalf("client never registered (count=%d)", clientCount(h))
 	}
-	if !waitFor(t, func() bool { return clientCount() == 0 }, 3*time.Second) {
-		t.Fatalf("unresponsive client was not reaped (count=%d)", clientCount())
+	if !waitFor(t, func() bool { return clientCount(h) == 0 }, 3*time.Second) {
+		t.Fatalf("unresponsive client was not reaped (count=%d)", clientCount(h))
 	}
 }
 
 // TestKeepalive_ResponsivePeerStaysConnected verifies that a client which reads
 // (and therefore auto-replies to pings) is not reaped.
 func TestKeepalive_ResponsivePeerStaysConnected(t *testing.T) {
-	resetClientState(t)
 	// Keep pongWait generously larger than pingPeriod so frequent pongs hold the
 	// deadline open even under the scheduling jitter of the race detector.
 	setKeepalive(t, 50*time.Millisecond, 600*time.Millisecond)
 
-	cfg := &config.Config{ContextRoot: "/"}
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		handleConnections(cfg, w, r)
-	}))
+	h := newHub(&config.Config{ContextRoot: "/"})
+	srv := httptest.NewServer(http.HandlerFunc(h.handleConnections))
 	defer srv.Close()
 
 	wsURL := "ws" + strings.TrimPrefix(srv.URL, "http") + "/ws"
@@ -105,13 +99,13 @@ func TestKeepalive_ResponsivePeerStaysConnected(t *testing.T) {
 		}
 	}()
 
-	if !waitFor(t, func() bool { return clientCount() == 1 }, 2*time.Second) {
-		t.Fatalf("client never registered (count=%d)", clientCount())
+	if !waitFor(t, func() bool { return clientCount(h) == 1 }, 2*time.Second) {
+		t.Fatalf("client never registered (count=%d)", clientCount(h))
 	}
 	// Past a full pongWait window (many ping/pong cycles), a responsive client
 	// must still be connected.
 	time.Sleep(pongWait() + 200*time.Millisecond)
-	if got := clientCount(); got != 1 {
+	if got := clientCount(h); got != 1 {
 		t.Fatalf("responsive client should stay connected, count=%d", got)
 	}
 

--- a/internal/docker/ws_integration_test.go
+++ b/internal/docker/ws_integration_test.go
@@ -1,0 +1,90 @@
+package docker
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/golang-jwt/jwt/v5"
+	"github.com/gorilla/websocket"
+
+	"github.com/jtgasper3/swarm-visualizer/internal/config"
+)
+
+// bearerValidator accepts only "Bearer good".
+func bearerValidator(r *http.Request) (jwt.MapClaims, error) {
+	if r.Header.Get("Authorization") == "Bearer good" {
+		return jwt.MapClaims{"sub": "alice"}, nil
+	}
+	return nil, fmt.Errorf("no valid token")
+}
+
+func wsServer(t *testing.T, h *Hub) (*httptest.Server, string) {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(h.handleConnections))
+	t.Cleanup(srv.Close)
+	return srv, "ws" + strings.TrimPrefix(srv.URL, "http") + "/ws"
+}
+
+// TestWS_AuthRejectsUnauthorized verifies that, with auth enabled, a connection
+// without a valid token receives the in-band 401 message and is not registered.
+func TestWS_AuthRejectsUnauthorized(t *testing.T) {
+	cfg := &config.Config{ContextRoot: "/", AuthEnabled: true, OAuthConfig: config.OAuthConfig{UsernameClaim: "sub"}}
+	h := newHub(cfg, bearerValidator)
+	_, wsURL := wsServer(t, h)
+
+	conn, _, err := websocket.DefaultDialer.Dial(wsURL, nil) // no Authorization header
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+	defer conn.Close()
+
+	conn.SetReadDeadline(time.Now().Add(2 * time.Second))
+	_, msg, err := conn.ReadMessage()
+	if err != nil {
+		t.Fatalf("expected a 401 message, got read error: %v", err)
+	}
+	if string(msg) != "401-Unauthorized" {
+		t.Fatalf("got %q, want 401-Unauthorized", msg)
+	}
+	if c := clientCount(h); c != 0 {
+		t.Fatalf("unauthorized client must not be registered, count=%d", c)
+	}
+}
+
+// TestWS_AuthAcceptsAndDelivers verifies that an authorized connection is
+// registered and receives the current snapshot.
+func TestWS_AuthAcceptsAndDelivers(t *testing.T) {
+	cfg := &config.Config{ContextRoot: "/", AuthEnabled: true, OAuthConfig: config.OAuthConfig{UsernameClaim: "sub"}}
+	h := newHub(cfg, bearerValidator)
+	go h.runBroadcasts()
+	_, wsURL := wsServer(t, h)
+
+	// Publish a frame and wait until it has been fanned out, so a newly
+	// connecting client is seeded with it.
+	frame := []byte(`{"clusterName":"x"}`)
+	h.Publish(frame)
+	if !waitFor(t, h.Ready, time.Second) {
+		t.Fatal("frame was never fanned out")
+	}
+
+	header := http.Header{}
+	header.Set("Authorization", "Bearer good")
+	conn, _, err := websocket.DefaultDialer.Dial(wsURL, header)
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+	defer conn.Close()
+
+	conn.SetReadDeadline(time.Now().Add(2 * time.Second))
+	_, msg, err := conn.ReadMessage()
+	if err != nil {
+		t.Fatalf("authorized client got no frame: %v", err)
+	}
+	if string(msg) != string(frame) {
+		t.Fatalf("got %q, want %q", msg, frame)
+	}
+}

--- a/internal/oauth/callback_test.go
+++ b/internal/oauth/callback_test.go
@@ -15,19 +15,19 @@ import (
 )
 
 func TestHandleLogin_SetsStateAndNonce(t *testing.T) {
-	orig := oauthConfig
-	t.Cleanup(func() { oauthConfig = orig })
-	oauthConfig = &oauth2.Config{
-		ClientID:    "client-1",
-		RedirectURL: "https://app.example.com/callback",
-		Endpoint:    oauth2.Endpoint{AuthURL: "https://issuer.example.com/auth"},
+	a := &Authenticator{
+		cfg: &config.Config{ContextRoot: "/"},
+		oauthConfig: &oauth2.Config{
+			ClientID:    "client-1",
+			RedirectURL: "https://app.example.com/callback",
+			Endpoint:    oauth2.Endpoint{AuthURL: "https://issuer.example.com/auth"},
+		},
 	}
 
-	cfg := &config.Config{ContextRoot: "/"}
 	req := httptest.NewRequest(http.MethodGet, "/login", nil)
 	rr := httptest.NewRecorder()
 
-	handleLogin(cfg, rr, req)
+	a.handleLogin(rr, req)
 
 	if rr.Code != http.StatusTemporaryRedirect {
 		t.Fatalf("status = %d, want %d", rr.Code, http.StatusTemporaryRedirect)
@@ -61,9 +61,7 @@ func TestHandleCallback_NonceValidation(t *testing.T) {
 	}
 	const kid, issuer, client = "kid1", "https://issuer.example.com", "client-1"
 
-	origKeys, origCfg := signingKeys, oauthConfig
-	t.Cleanup(func() { signingKeys = origKeys; oauthConfig = origCfg })
-	signingKeys = &keyStore{
+	keys := &keyStore{
 		keys:        map[string]*rsa.PublicKey{kid: &key.PublicKey},
 		lastRefresh: time.Now(),
 	}
@@ -95,16 +93,20 @@ func TestHandleCallback_NonceValidation(t *testing.T) {
 		}))
 		defer tokenSrv.Close()
 
-		oauthConfig = &oauth2.Config{
-			ClientID: client,
-			Endpoint: oauth2.Endpoint{TokenURL: tokenSrv.URL, AuthURL: "https://issuer.example.com/auth"},
+		a := &Authenticator{
+			cfg:  cfg,
+			keys: keys,
+			oauthConfig: &oauth2.Config{
+				ClientID: client,
+				Endpoint: oauth2.Endpoint{TokenURL: tokenSrv.URL, AuthURL: "https://issuer.example.com/auth"},
+			},
 		}
 
 		req := httptest.NewRequest(http.MethodGet, "/callback?code=abc&state=xyz", nil)
 		req.AddCookie(&http.Cookie{Name: "state", Value: "xyz"})
 		req.AddCookie(&http.Cookie{Name: "nonce", Value: cookieNonce})
 		rr := httptest.NewRecorder()
-		handleCallback(cfg, rr, req)
+		a.handleCallback(rr, req)
 		return rr
 	}
 
@@ -139,11 +141,11 @@ func TestHandleCallback_NonceValidation(t *testing.T) {
 }
 
 func TestHandleLogout_ClearsSession(t *testing.T) {
-	cfg := &config.Config{ContextRoot: "/"}
+	a := &Authenticator{cfg: &config.Config{ContextRoot: "/"}}
 	req := httptest.NewRequest(http.MethodGet, "/logout", nil)
 	rr := httptest.NewRecorder()
 
-	handleLogout(cfg, rr, req)
+	a.handleLogout(rr, req)
 
 	if rr.Code != http.StatusTemporaryRedirect {
 		t.Fatalf("status = %d, want %d", rr.Code, http.StatusTemporaryRedirect)

--- a/internal/oauth/idtoken.go
+++ b/internal/oauth/idtoken.go
@@ -6,10 +6,11 @@ import (
 	"strings"
 
 	"github.com/golang-jwt/jwt/v5"
-	"github.com/jtgasper3/swarm-visualizer/internal/config"
 )
 
-func ValidateToken(cfg *config.Config, r *http.Request) (jwt.MapClaims, error) {
+// ValidateToken extracts the ID token from the request (cookie or bearer
+// header) and verifies it.
+func (a *Authenticator) ValidateToken(r *http.Request) (jwt.MapClaims, error) {
 	var rawIDToken string
 	cookie, err := r.Cookie("id_token")
 	if err != nil {
@@ -23,13 +24,13 @@ func ValidateToken(cfg *config.Config, r *http.Request) (jwt.MapClaims, error) {
 		rawIDToken = cookie.Value
 	}
 
-	return validateRawToken(cfg, rawIDToken)
+	return a.validateRawToken(rawIDToken)
 }
 
 // validateRawToken verifies an ID token's signature, issuer, and audience and
 // returns its claims. It is shared by the WebSocket request path and the OAuth
 // callback (which additionally checks the nonce).
-func validateRawToken(cfg *config.Config, rawIDToken string) (jwt.MapClaims, error) {
+func (a *Authenticator) validateRawToken(rawIDToken string) (jwt.MapClaims, error) {
 	token, err := jwt.Parse(rawIDToken, func(token *jwt.Token) (interface{}, error) {
 		if _, ok := token.Method.(*jwt.SigningMethodRSA); !ok {
 			return nil, fmt.Errorf("unexpected signing method: %v", token.Header["alg"])
@@ -40,10 +41,10 @@ func validateRawToken(cfg *config.Config, rawIDToken string) (jwt.MapClaims, err
 			return nil, fmt.Errorf("missing kid in token header")
 		}
 
-		if signingKeys == nil {
+		if a.keys == nil {
 			return nil, fmt.Errorf("signing keys not initialized")
 		}
-		rsaPublicKey, ok := signingKeys.key(kid)
+		rsaPublicKey, ok := a.keys.key(kid)
 		if !ok {
 			return nil, fmt.Errorf("unknown kid: %s", kid)
 		}
@@ -59,12 +60,12 @@ func validateRawToken(cfg *config.Config, rawIDToken string) (jwt.MapClaims, err
 		return nil, fmt.Errorf("unauthorized")
 	}
 
-	if cfg.OAuthConfig.Issuer != "" {
+	if a.cfg.OAuthConfig.Issuer != "" {
 		issuer, err := claims.GetIssuer()
 		if err != nil {
 			return nil, fmt.Errorf("failed to read issuer claim: %v", err)
 		}
-		if issuer != cfg.OAuthConfig.Issuer {
+		if issuer != a.cfg.OAuthConfig.Issuer {
 			return nil, fmt.Errorf("ID token from unexpected issuer: %s", issuer)
 		}
 	}
@@ -75,7 +76,7 @@ func validateRawToken(cfg *config.Config, rawIDToken string) (jwt.MapClaims, err
 	}
 	validAudience := false
 	for _, aud := range audiences {
-		if aud == cfg.OAuthConfig.ClientID {
+		if aud == a.cfg.OAuthConfig.ClientID {
 			validAudience = true
 			break
 		}

--- a/internal/oauth/idtoken_test.go
+++ b/internal/oauth/idtoken_test.go
@@ -28,10 +28,9 @@ func TestValidateToken(t *testing.T) {
 		client = "client-123"
 	)
 
-	// Point the package-level key store at our test key.
-	orig := signingKeys
-	t.Cleanup(func() { signingKeys = orig })
-	signingKeys = &keyStore{
+	// keyStore seeded with our test key. lastRefresh is recent so an unknown kid
+	// does not trigger a (network) refresh.
+	keys := &keyStore{
 		keys:        map[string]*rsa.PublicKey{kid: &key.PublicKey},
 		lastRefresh: time.Now(),
 	}
@@ -120,7 +119,8 @@ func TestValidateToken(t *testing.T) {
 				}
 			}
 
-			claims, err := ValidateToken(cfg, req)
+			a := &Authenticator{cfg: cfg, keys: keys}
+			claims, err := a.ValidateToken(req)
 			if tc.wantErr {
 				if err == nil {
 					t.Fatalf("expected error, got nil (claims=%v)", claims)

--- a/internal/oauth/integration_test.go
+++ b/internal/oauth/integration_test.go
@@ -1,0 +1,87 @@
+package oauth
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/jtgasper3/swarm-visualizer/internal/config"
+	"golang.org/x/oauth2"
+)
+
+// newTestAuthenticator builds an Authenticator wired for handler tests, without
+// the network discovery that NewAuthenticator performs.
+func newTestAuthenticator() *Authenticator {
+	return &Authenticator{
+		cfg: &config.Config{ContextRoot: "/"},
+		oauthConfig: &oauth2.Config{
+			ClientID: "client-1",
+			Endpoint: oauth2.Endpoint{AuthURL: "https://idp.example.com/auth"},
+		},
+		limiters: make(map[string]*ipLimiter),
+	}
+}
+
+// TestOAuthRoutes_ThroughMux exercises the registered login and logout routes
+// end to end via a ServeMux.
+func TestOAuthRoutes_ThroughMux(t *testing.T) {
+	a := newTestAuthenticator()
+	mux := http.NewServeMux()
+	a.register(mux)
+
+	// /login redirects to the IdP authorize endpoint.
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/login", nil)
+	req.RemoteAddr = "1.2.3.4:1111"
+	mux.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusTemporaryRedirect {
+		t.Fatalf("login status = %d, want %d", rr.Code, http.StatusTemporaryRedirect)
+	}
+	if loc := rr.Header().Get("Location"); !strings.HasPrefix(loc, "https://idp.example.com/auth?") {
+		t.Fatalf("login Location = %q, want IdP authorize URL", loc)
+	}
+
+	// /logout clears the session cookie.
+	rr = httptest.NewRecorder()
+	req = httptest.NewRequest(http.MethodGet, "/logout", nil)
+	req.RemoteAddr = "1.2.3.4:1111"
+	mux.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusTemporaryRedirect {
+		t.Fatalf("logout status = %d, want %d", rr.Code, http.StatusTemporaryRedirect)
+	}
+	cleared := false
+	for _, c := range rr.Result().Cookies() {
+		if c.Name == "id_token" && c.MaxAge < 0 {
+			cleared = true
+		}
+	}
+	if !cleared {
+		t.Fatal("logout did not clear the id_token cookie")
+	}
+}
+
+// TestOAuthRateLimit verifies the per-IP rate limiter on the auth endpoints
+// returns 429 once the burst is exceeded.
+func TestOAuthRateLimit(t *testing.T) {
+	a := newTestAuthenticator()
+	mux := http.NewServeMux()
+	a.register(mux)
+
+	got429 := false
+	for i := 0; i < 8; i++ {
+		rr := httptest.NewRecorder()
+		req := httptest.NewRequest(http.MethodGet, "/login", nil)
+		req.RemoteAddr = "9.9.9.9:2222"
+		mux.ServeHTTP(rr, req)
+		if rr.Code == http.StatusTooManyRequests {
+			got429 = true
+			break
+		}
+	}
+	if !got429 {
+		t.Fatal("expected a 429 after exceeding the burst limit")
+	}
+}

--- a/internal/oauth/jwks.go
+++ b/internal/oauth/jwks.go
@@ -33,10 +33,6 @@ type keyStore struct {
 	lastRefresh time.Time
 }
 
-// signingKeys is populated during OIDC discovery (fetchWellKnownOIDCConfig)
-// before any token is validated.
-var signingKeys *keyStore
-
 // newKeyStore creates a key store for the given JWKS endpoint. Callers must
 // invoke refresh once to populate it before validating tokens.
 func newKeyStore(jwksURI string, httpClient *http.Client) *keyStore {

--- a/internal/oauth/oauth.go
+++ b/internal/oauth/oauth.go
@@ -115,14 +115,13 @@ func RegisterOAuthHandlers(mux *http.ServeMux, cfg *config.Config) *Authenticato
 	if err != nil {
 		log.Fatalf("Failed to initialize authentication: %v", err)
 	}
+	go auth.cleanupLimiters()
 	auth.register(mux)
 	return auth
 }
 
-// register wires the auth endpoints onto mux and starts the limiter cleanup.
+// register wires the auth endpoints onto mux.
 func (a *Authenticator) register(mux *http.ServeMux) {
-	go a.cleanupLimiters()
-
 	mux.HandleFunc(a.cfg.ContextRoot+"login", func(w http.ResponseWriter, r *http.Request) {
 		if !a.authLimiter(clientIP(r, a.cfg.TrustedProxies)).Allow() {
 			http.Error(w, "Too Many Requests", http.StatusTooManyRequests)

--- a/internal/oauth/oauth.go
+++ b/internal/oauth/oauth.go
@@ -19,17 +19,33 @@ import (
 	"golang.org/x/time/rate"
 )
 
-var oauthConfig *oauth2.Config
+// Authenticator holds the OIDC configuration, JWKS signing keys, and per-IP
+// rate limiters for the auth endpoints. One instance backs the running server;
+// tests construct their own.
+type Authenticator struct {
+	cfg         *config.Config
+	oauthConfig *oauth2.Config
+	keys        *keyStore
+
+	limitersMu sync.Mutex
+	limiters   map[string]*ipLimiter
+}
 
 type ipLimiter struct {
 	limiter  *rate.Limiter
 	lastSeen time.Time
 }
 
-var (
-	authLimiters   = make(map[string]*ipLimiter)
-	authLimitersMu sync.Mutex
-)
+// NewAuthenticator discovers the OIDC endpoints and JWKS, then builds the
+// oauth2 config. It performs network I/O.
+func NewAuthenticator(cfg *config.Config) (*Authenticator, error) {
+	a := &Authenticator{cfg: cfg, limiters: make(map[string]*ipLimiter)}
+	if err := a.fetchWellKnownOIDCConfig(); err != nil {
+		return nil, err
+	}
+	a.oauthConfig = setupOAuthConfig(&cfg.OAuthConfig)
+	return a, nil
+}
 
 // clientIP returns the real client IP. If the direct connection is from a
 // trusted proxy, X-Real-IP and X-Forwarded-For headers are consulted instead.
@@ -58,66 +74,72 @@ func clientIP(r *http.Request, trustedProxies []*net.IPNet) string {
 	return host
 }
 
-// getAuthLimiter returns a rate limiter for the given IP, creating one if needed.
+// authLimiter returns a rate limiter for the given IP, creating one if needed.
 // Allows 5 requests per minute with a burst of 5.
-func getAuthLimiter(ip string) *rate.Limiter {
-	authLimitersMu.Lock()
-	defer authLimitersMu.Unlock()
+func (a *Authenticator) authLimiter(ip string) *rate.Limiter {
+	a.limitersMu.Lock()
+	defer a.limitersMu.Unlock()
 
-	l, ok := authLimiters[ip]
+	l, ok := a.limiters[ip]
 	if !ok {
 		l = &ipLimiter{limiter: rate.NewLimiter(rate.Every(time.Minute/5), 5)}
-		authLimiters[ip] = l
+		a.limiters[ip] = l
 	}
 	l.lastSeen = time.Now()
 	return l.limiter
 }
 
-// cleanupAuthLimiters removes entries not seen in the last 10 minutes.
-func cleanupAuthLimiters() {
+// cleanupLimiters removes entries not seen in the last 10 minutes.
+func (a *Authenticator) cleanupLimiters() {
 	for {
 		time.Sleep(5 * time.Minute)
-		authLimitersMu.Lock()
-		for ip, l := range authLimiters {
+		a.limitersMu.Lock()
+		for ip, l := range a.limiters {
 			if time.Since(l.lastSeen) > 10*time.Minute {
-				delete(authLimiters, ip)
+				delete(a.limiters, ip)
 			}
 		}
-		authLimitersMu.Unlock()
+		a.limitersMu.Unlock()
 	}
 }
 
-func RegisterOAuthHandlers(mux *http.ServeMux, cfg *config.Config) {
-	if cfg.AuthEnabled {
-		// Fetch and parse the well-known OIDC config before building the
-		// oauth2.Config so discovered auth/token endpoints are included.
-		err := fetchWellKnownOIDCConfig(cfg)
-		if err != nil {
-			log.Fatalf("Failed to fetch JWKS: %v", err)
-		}
-
-		oauthConfig = setupOAuthConfig(&cfg.OAuthConfig)
-
-		go cleanupAuthLimiters()
-
-		mux.HandleFunc(cfg.ContextRoot+"login", func(w http.ResponseWriter, r *http.Request) {
-			if !getAuthLimiter(clientIP(r, cfg.TrustedProxies)).Allow() {
-				http.Error(w, "Too Many Requests", http.StatusTooManyRequests)
-				return
-			}
-			handleLogin(cfg, w, r)
-		})
-		mux.HandleFunc(cfg.ContextRoot+"callback", func(w http.ResponseWriter, r *http.Request) {
-			if !getAuthLimiter(clientIP(r, cfg.TrustedProxies)).Allow() {
-				http.Error(w, "Too Many Requests", http.StatusTooManyRequests)
-				return
-			}
-			handleCallback(cfg, w, r)
-		})
-		mux.HandleFunc(cfg.ContextRoot+"logout", func(w http.ResponseWriter, r *http.Request) {
-			handleLogout(cfg, w, r)
-		})
+// RegisterOAuthHandlers builds the Authenticator and wires its endpoints onto
+// mux when authentication is enabled. It returns the Authenticator (whose
+// ValidateToken the WebSocket handler uses), or nil when auth is disabled.
+func RegisterOAuthHandlers(mux *http.ServeMux, cfg *config.Config) *Authenticator {
+	if !cfg.AuthEnabled {
+		return nil
 	}
+
+	auth, err := NewAuthenticator(cfg)
+	if err != nil {
+		log.Fatalf("Failed to initialize authentication: %v", err)
+	}
+	auth.register(mux)
+	return auth
+}
+
+// register wires the auth endpoints onto mux and starts the limiter cleanup.
+func (a *Authenticator) register(mux *http.ServeMux) {
+	go a.cleanupLimiters()
+
+	mux.HandleFunc(a.cfg.ContextRoot+"login", func(w http.ResponseWriter, r *http.Request) {
+		if !a.authLimiter(clientIP(r, a.cfg.TrustedProxies)).Allow() {
+			http.Error(w, "Too Many Requests", http.StatusTooManyRequests)
+			return
+		}
+		a.handleLogin(w, r)
+	})
+	mux.HandleFunc(a.cfg.ContextRoot+"callback", func(w http.ResponseWriter, r *http.Request) {
+		if !a.authLimiter(clientIP(r, a.cfg.TrustedProxies)).Allow() {
+			http.Error(w, "Too Many Requests", http.StatusTooManyRequests)
+			return
+		}
+		a.handleCallback(w, r)
+	})
+	mux.HandleFunc(a.cfg.ContextRoot+"logout", func(w http.ResponseWriter, r *http.Request) {
+		a.handleLogout(w, r)
+	})
 }
 
 func setupOAuthConfig(cfg *config.OAuthConfig) *oauth2.Config {
@@ -133,7 +155,7 @@ func setupOAuthConfig(cfg *config.OAuthConfig) *oauth2.Config {
 	}
 }
 
-func handleLogin(cfg *config.Config, w http.ResponseWriter, r *http.Request) {
+func (a *Authenticator) handleLogin(w http.ResponseWriter, r *http.Request) {
 	state, err := generateSecureRandomString(32)
 	if err != nil {
 		http.Error(w, fmt.Sprintf("Failed to generate state: %v", err), http.StatusInternalServerError)
@@ -148,16 +170,16 @@ func handleLogin(cfg *config.Config, w http.ResponseWriter, r *http.Request) {
 	// state binds the callback to this browser (CSRF); nonce binds the issued
 	// ID token to this login flow (replay protection) and is validated against
 	// the token's nonce claim in the callback.
-	url := oauthConfig.AuthCodeURL(state, oauth2.SetAuthURLParam("nonce", nonce))
-	setFlowCookie(cfg, w, "state", state)
-	setFlowCookie(cfg, w, "nonce", nonce)
+	url := a.oauthConfig.AuthCodeURL(state, oauth2.SetAuthURLParam("nonce", nonce))
+	setFlowCookie(a.cfg, w, "state", state)
+	setFlowCookie(a.cfg, w, "nonce", nonce)
 	http.Redirect(w, r, url, http.StatusTemporaryRedirect)
 }
 
-func handleCallback(cfg *config.Config, w http.ResponseWriter, r *http.Request) {
+func (a *Authenticator) handleCallback(w http.ResponseWriter, r *http.Request) {
 	stateCookie, err := r.Cookie("state")
 	if err != nil || subtle.ConstantTimeCompare([]byte(stateCookie.Value), []byte(r.URL.Query().Get("state"))) != 1 {
-		clearFlowCookies(cfg, w)
+		clearFlowCookies(a.cfg, w)
 		http.Error(w, "Invalid state", http.StatusBadRequest)
 		return
 	}
@@ -168,58 +190,59 @@ func handleCallback(cfg *config.Config, w http.ResponseWriter, r *http.Request) 
 	defer cancel()
 
 	code := r.URL.Query().Get("code")
-	token, err := oauthConfig.Exchange(ctx, code)
+	token, err := a.oauthConfig.Exchange(ctx, code)
 	if err != nil {
-		clearFlowCookies(cfg, w)
+		clearFlowCookies(a.cfg, w)
 		http.Error(w, fmt.Sprintf("Failed to exchange token: %v", err), http.StatusInternalServerError)
 		return
 	}
 
 	rawIDToken, ok := token.Extra("id_token").(string)
 	if !ok {
-		clearFlowCookies(cfg, w)
+		clearFlowCookies(a.cfg, w)
 		http.Error(w, "No id_token found", http.StatusInternalServerError)
 		return
 	}
 
 	// Validate the ID token and bind it to this login flow via the nonce, so a
 	// token captured or replayed from a different flow cannot be used here.
-	claims, err := validateRawToken(cfg, rawIDToken)
+	claims, err := a.validateRawToken(rawIDToken)
 	if err != nil {
-		clearFlowCookies(cfg, w)
+		clearFlowCookies(a.cfg, w)
 		log.Printf("Callback ID token validation failed: %s %v", r.RemoteAddr, err)
 		http.Error(w, "Invalid ID token", http.StatusUnauthorized)
 		return
 	}
 	nonceCookie, err := r.Cookie("nonce")
 	if err != nil {
-		clearFlowCookies(cfg, w)
+		clearFlowCookies(a.cfg, w)
 		http.Error(w, "Missing nonce", http.StatusBadRequest)
 		return
 	}
 	tokenNonce, _ := claims["nonce"].(string)
 	if tokenNonce == "" || subtle.ConstantTimeCompare([]byte(tokenNonce), []byte(nonceCookie.Value)) != 1 {
-		clearFlowCookies(cfg, w)
+		clearFlowCookies(a.cfg, w)
 		log.Printf("Callback nonce mismatch: %s", r.RemoteAddr)
 		http.Error(w, "Invalid nonce", http.StatusBadRequest)
 		return
 	}
 
-	clearFlowCookies(cfg, w)
+	clearFlowCookies(a.cfg, w)
 
 	http.SetCookie(w, &http.Cookie{
 		Name:     "id_token",
 		Value:    rawIDToken,
-		MaxAge:   cfg.OAuthConfig.SessionMaxAge,
-		Path:     cfg.ContextRoot,
+		MaxAge:   a.cfg.OAuthConfig.SessionMaxAge,
+		Path:     a.cfg.ContextRoot,
 		HttpOnly: true,
 		Secure:   true,
 		SameSite: http.SameSiteStrictMode,
 	})
-	http.Redirect(w, r, cfg.ContextRoot, http.StatusTemporaryRedirect)
+	http.Redirect(w, r, a.cfg.ContextRoot, http.StatusTemporaryRedirect)
 }
 
-func fetchWellKnownOIDCConfig(cfg *config.Config) error {
+func (a *Authenticator) fetchWellKnownOIDCConfig() error {
+	cfg := a.cfg
 	httpClient := &http.Client{Timeout: 10 * time.Second}
 
 	wellKnownURL := cfg.OAuthConfig.OIDCWellKnownURL
@@ -258,11 +281,11 @@ func fetchWellKnownOIDCConfig(cfg *config.Config) error {
 		return fmt.Errorf("well-known configuration provided no jwks_uri")
 	}
 
-	signingKeys = newKeyStore(discovery.JWKSURI, httpClient)
-	if err := signingKeys.refresh(); err != nil {
+	a.keys = newKeyStore(discovery.JWKSURI, httpClient)
+	if err := a.keys.refresh(); err != nil {
 		return err
 	}
-	go signingKeys.refreshLoop()
+	go a.keys.refreshLoop()
 
 	return nil
 }
@@ -270,18 +293,18 @@ func fetchWellKnownOIDCConfig(cfg *config.Config) error {
 // handleLogout clears the session cookie and returns the user to the app,
 // which will then prompt for login again. This is a local logout; it does not
 // terminate the session at the identity provider.
-func handleLogout(cfg *config.Config, w http.ResponseWriter, r *http.Request) {
+func (a *Authenticator) handleLogout(w http.ResponseWriter, r *http.Request) {
 	http.SetCookie(w, &http.Cookie{
 		Name:     "id_token",
 		Value:    "",
-		Path:     cfg.ContextRoot,
+		Path:     a.cfg.ContextRoot,
 		HttpOnly: true,
 		Secure:   true,
 		SameSite: http.SameSiteStrictMode,
 		Expires:  time.Unix(0, 0),
 		MaxAge:   -1,
 	})
-	http.Redirect(w, r, cfg.ContextRoot, http.StatusTemporaryRedirect)
+	http.Redirect(w, r, a.cfg.ContextRoot, http.StatusTemporaryRedirect)
 }
 
 // setFlowCookie sets a short-lived cookie used during the OAuth redirect flow.

--- a/internal/oauth/oauth_test.go
+++ b/internal/oauth/oauth_test.go
@@ -130,13 +130,6 @@ func TestRegisterOAuthHandlersUsesDiscoveredEndpoints(t *testing.T) {
 	}))
 	defer discovery.Close()
 
-	origOAuthConfig := oauthConfig
-	origSigningKeys := signingKeys
-	t.Cleanup(func() {
-		oauthConfig = origOAuthConfig
-		signingKeys = origSigningKeys
-	})
-
 	cfg := &config.Config{
 		ContextRoot: "/",
 		AuthEnabled: true,
@@ -148,13 +141,16 @@ func TestRegisterOAuthHandlersUsesDiscoveredEndpoints(t *testing.T) {
 	}
 
 	mux := http.NewServeMux()
-	RegisterOAuthHandlers(mux, cfg)
-
-	if oauthConfig.Endpoint.AuthURL != "https://issuer.example.com/auth" {
-		t.Fatalf("AuthURL = %q, want discovered endpoint", oauthConfig.Endpoint.AuthURL)
+	auth := RegisterOAuthHandlers(mux, cfg)
+	if auth == nil {
+		t.Fatal("expected an Authenticator when auth is enabled")
 	}
-	if oauthConfig.Endpoint.TokenURL != "https://issuer.example.com/token" {
-		t.Fatalf("TokenURL = %q, want discovered endpoint", oauthConfig.Endpoint.TokenURL)
+
+	if auth.oauthConfig.Endpoint.AuthURL != "https://issuer.example.com/auth" {
+		t.Fatalf("AuthURL = %q, want discovered endpoint", auth.oauthConfig.Endpoint.AuthURL)
+	}
+	if auth.oauthConfig.Endpoint.TokenURL != "https://issuer.example.com/token" {
+		t.Fatalf("TokenURL = %q, want discovered endpoint", auth.oauthConfig.Endpoint.TokenURL)
 	}
 
 	req := httptest.NewRequest(http.MethodGet, "/login", nil)


### PR DESCRIPTION
Recovery PR. The #13 stack (#51–#54) was merged bottom-first, so only **stage 1** (#51) actually reached `main`; stages 2–4 were merged into the intermediate stacked branches and never propagated. This brings the remaining three stages onto `main`.

Contents (the clean stage commits, on top of the stage 1 already on `main`):
- **#13 stage 2** — move WebSocket fan-out state into a `Hub`.
- **#13 stage 3** — retire oauth globals into an `Authenticator`; decouple the WS handler from `oauth` via a `TokenValidator`.
- **#13 stage 4** — `/ws` + OAuth integration tests.

Already reviewed as PRs #52, #53, #54. Verified here: `go build` / `go vet` / `go test ./...` green, and a test-merge into `main` applies with no conflicts.

After this merges, the stale stacked branches (`refactor-13-mux`, `-hub`, `-authenticator`, `-integration-tests`) can be deleted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)