### PR TITLE
Bump Go to 1.26.5 (go.mod + builder image)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Use the official Golang image as the build stage
-FROM golang:1.26@sha256:32c0e6e5c4f6707717051091b4d0b077464a679eaab563e11474efc5328e2aa5 AS builder
+FROM golang:1.26@sha256:3aff6657219a4d9c14e27fb1d8976c49c29fddb70ba835014f477e1c70636647 AS builder
 
 WORKDIR /app
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/jtgasper3/swarm-visualizer
 
-go 1.26.4
+go 1.26.5
 
 require (
 	github.com/golang-jwt/jwt/v5 v5.3.1


### PR DESCRIPTION
Merges `jtgasper3-patch-1` and aligns the Dockerfile builder image with it.

- `go.mod`: `go 1.26.4` → `1.26.5` (from `jtgasper3-patch-1`)
- `Dockerfile`: builder digest `32c0e6e…` → `3aff6657…`

The `golang:1.26` tag is kept floating per repo convention; the new digest was verified to carry `GOLANG_VERSION=1.26.5`. `go build ./...` passes locally on go1.26.5.

Supersedes the open Dependabot digest PR for `golang-079e598` — that digest is older than this one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)